### PR TITLE
Fixing three showstopper bugs, including #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mcp-server-siri-shortcuts",
-  "version": "1.1.0",
+  "name": "mcp-server-devonthink",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-server-siri-shortcuts",
-      "version": "1.1.0",
+      "name": "mcp-server-devonthink",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -15,7 +15,7 @@
         "zod-to-json-schema": "^3.23.5"
       },
       "bin": {
-        "mcp-server-siri-shortcuts": "dist/index.js"
+        "mcp-server-devonthink": "dist/index.js"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "bugs": "https://github.com/dvcrn/mcp-server-devonthink/issues",
   "type": "module",
   "bin": {
-    "mcp-server-devonthink": "dist/src/index.js"
+    "mcp-server-devonthink": "dist/index.js"
   },
   "files": [
-    "dist/src"
+    "dist"
   ],
   "scripts": {
-    "build": "tsc && shx chmod +x dist/*.js",
+    "build": "tsc && shx chmod +x dist/index.js",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "format": "biome format --write",

--- a/src/devonthink.ts
+++ b/src/devonthink.ts
@@ -5,6 +5,7 @@ import {
   ErrorCode,
   ListResourcesRequestSchema,
   ListPromptsRequestSchema,
+  ListResourceTemplatesRequestSchema,
   McpError,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -76,6 +77,10 @@ export const createServer = async () => {
   });
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    return { resources: [] };
+  });
+
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
     return { resources: [] };
   });
 


### PR DESCRIPTION
Three issues were preventing running the MCP server using npx:
1. The lock file actually is the one from https://github.com/dvcrn/mcp-server-siri-shortcuts, so had to rename a number of fields.
2. The package.json file referred to dist/src/*.js files, but there is no src subfolder under dist/. This fixes #1 
3. The resources/templates/list API was not supported by the server, now returning an empty list.

The MCP server now seems to run correctly using DevonThink 3.9.13 on the latest MacOS.