### PR TITLE
Fix DEVONthink 4.1 compatibility: support both auditProof and revisionProof

### DIFF
--- a/src/tools/getCurrentDatabase.ts
+++ b/src/tools/getCurrentDatabase.ts
@@ -15,7 +15,8 @@ interface DatabaseInfo {
   path: string;
   filename: string;
   encrypted: boolean;
-  auditProof: boolean;
+  revisionProof?: boolean; // DEVONthink 4.1 and later
+  auditProof?: boolean;    // DEVONthink before 4.1
   readOnly: boolean;
   spotlightIndexing: boolean;
   versioning: boolean;
@@ -51,11 +52,21 @@ const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
           path: currentDb.path(),
           filename: currentDb.filename(),
           encrypted: currentDb.encrypted(),
-          auditProof: currentDb.auditProof(),
           readOnly: currentDb.readOnly(),
           spotlightIndexing: currentDb.spotlightIndexing(),
           versioning: currentDb.versioning()
         };
+        
+        // Handle audit/revision proof compatibility: before 4.1 vs 4.1 and later
+        try {
+          databaseInfo["revisionProof"] = currentDb.revisionProof(); // 4.1 and later
+        } catch (e) {
+          try {
+            databaseInfo["auditProof"] = currentDb.auditProof(); // before 4.1
+          } catch (e2) {
+            // fallback if neither works - don't add any property
+          }
+        }
         
         // Add comment if available
         if (currentDb.comment && currentDb.comment()) {

--- a/src/tools/getOpenDatabases.ts
+++ b/src/tools/getOpenDatabases.ts
@@ -15,7 +15,8 @@ interface DatabaseInfo {
   path: string;
   filename: string;
   encrypted: boolean;
-  auditProof: boolean;
+  revisionProof?: boolean; // DEVONthink 4.1 and later
+  auditProof?: boolean;    // DEVONthink before 4.1
   readOnly: boolean;
   spotlightIndexing: boolean;
   versioning: boolean;
@@ -54,11 +55,21 @@ const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
             path: db.path(),
             filename: db.filename(),
             encrypted: db.encrypted(),
-            auditProof: db.auditProof(),
             readOnly: db.readOnly(),
             spotlightIndexing: db.spotlightIndexing(),
             versioning: db.versioning()
           };
+          
+          // Handle audit/revision proof compatibility: before 4.1 vs 4.1 and later
+          try {
+            info["revisionProof"] = db.revisionProof(); // 4.1 and later
+          } catch (e) {
+            try {
+              info["auditProof"] = db.auditProof(); // before 4.1
+            } catch (e2) {
+              // fallback if neither works - don't add any property
+            }
+          }
           
           // Add comment if available
           if (db.comment && db.comment()) {


### PR DESCRIPTION
## Summary
- Fixes "Can't convert types" error in `get_open_databases` and `current_database` tools when using DEVONthink 4.1
- DEVONthink 4.1 renamed "audit-proof" to "revision-proof" - the `auditProof()` method no longer exists
- Implements backward compatibility by trying both methods and using appropriate property names

## Changes
- Updated TypeScript interfaces to support both `auditProof` (4.0) and `revisionProof` (4.1+) as optional properties
- Added version detection logic that tries `revisionProof()` first, falls back to `auditProof()` 
- Response dynamically uses the correct property name based on which method succeeds
- No breaking changes - maintains full backward compatibility

## Test plan
- [x] Build succeeds with TypeScript
- [ ] Test with DEVONthink 4.0 (should show `auditProof` property)
- [ ] Test with DEVONthink 4.1 (should show `revisionProof` property)
- [ ] Verify no "Can't convert types" errors

🤖 Generated with [Claude Code](https://claude.ai/code)