### PR TITLE
Refactor utility tests and broaden formatting coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
 		"build": "tsc && shx chmod +x dist/index.js",
 		"prepare": "npm run build",
 		"watch": "tsc --watch",
-		"format": "biome format --write",
+		"format": "biome format --write .",
 		"lint:fix": "biome lint --fix",
 		"start": "node dist/index.js",
 		"type-check": "tsc --noEmit",
 		"test": "vitest run",
-		"format:check": "biome format package.json src/utils/**/*"
+		"format:check": "biome format ."
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "1.0.1",

--- a/src/applescript/execute.ts
+++ b/src/applescript/execute.ts
@@ -1,36 +1,28 @@
 import { exec } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 export const executeJxa = <T>(script: string): Promise<T> => {
-  return new Promise((resolve, reject) => {
-    const command = `osascript -l JavaScript -e '${script.replace(
-      /'/g,
-      "''"
-    )}'`;
-    exec(command, (error, stdout, stderr) => {
-      if (error) {
-        return reject(
-          new McpError(
-            ErrorCode.InternalError,
-            `JXA execution failed: ${error.message}`
-          )
-        );
-      }
-      if (stderr) {
-        return reject(
-          new McpError(ErrorCode.InternalError, `JXA error: ${stderr}`)
-        );
-      }
-      try {
-        const result = JSON.parse(stdout.trim());
-        resolve(result as T);
-      } catch (parseError) {
-        reject(
-          new McpError(
-            ErrorCode.InternalError,
-            `Failed to parse JXA output: ${parseError}`
-          )
-        );
-      }
-    });
-  });
+	return new Promise((resolve, reject) => {
+		const command = `osascript -l JavaScript -e '${script.replace(/'/g, "''")}'`;
+		exec(command, (error, stdout, stderr) => {
+			if (error) {
+				return reject(
+					new McpError(ErrorCode.InternalError, `JXA execution failed: ${error.message}`),
+				);
+			}
+			if (stderr) {
+				return reject(new McpError(ErrorCode.InternalError, `JXA error: ${stderr}`));
+			}
+			try {
+				const result = JSON.parse(stdout.trim());
+				resolve(result as T);
+			} catch (parseError) {
+				reject(
+					new McpError(
+						ErrorCode.InternalError,
+						`Failed to parse JXA output: ${parseError}`,
+					),
+				);
+			}
+		});
+	});
 };

--- a/src/devonthink.ts
+++ b/src/devonthink.ts
@@ -1,13 +1,13 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  ErrorCode,
-  ListResourcesRequestSchema,
-  ListPromptsRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  McpError,
-  Tool,
+	CallToolRequestSchema,
+	ListToolsRequestSchema,
+	ErrorCode,
+	ListResourcesRequestSchema,
+	ListPromptsRequestSchema,
+	ListResourceTemplatesRequestSchema,
+	McpError,
+	Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { isRunningTool } from "./tools/isRunning.js";
 import { createRecordTool } from "./tools/createRecord.js";
@@ -34,97 +34,94 @@ import { convertRecordTool } from "./tools/convertRecord.js";
 import { updateRecordContentTool } from "./tools/updateRecordContent.js";
 
 export const createServer = async () => {
-  const server = new Server(
-    {
-      name: "devonthink-mcp",
-      version: "0.1.0",
-    },
-    {
-      capabilities: {
-        tools: {},
-        resources: {},
-        prompts: {},
-      },
-    }
-  );
+	const server = new Server(
+		{
+			name: "devonthink-mcp",
+			version: "0.1.0",
+		},
+		{
+			capabilities: {
+				tools: {},
+				resources: {},
+				prompts: {},
+			},
+		},
+	);
 
-  const tools: Tool[] = [
-    isRunningTool,
-    createRecordTool,
-    deleteRecordTool,
-    moveRecordTool,
-    getRecordPropertiesTool,
-    getRecordByIdentifierTool,
-    searchTool,
-    lookupRecordTool,
-    createFromUrlTool,
-    getOpenDatabasesTool,
-    currentDatabaseTool,
-    selectedRecordsTool,
-    listGroupContentTool,
-    getRecordContentTool,
-    renameRecordTool,
-    addTagsTool,
-    removeTagsTool,
-    classifyTool,
-    compareTool,
-    replicateRecordTool,
-    duplicateRecordTool,
-    convertRecordTool,
-    updateRecordContentTool,
-  ];
+	const tools: Tool[] = [
+		isRunningTool,
+		createRecordTool,
+		deleteRecordTool,
+		moveRecordTool,
+		getRecordPropertiesTool,
+		getRecordByIdentifierTool,
+		searchTool,
+		lookupRecordTool,
+		createFromUrlTool,
+		getOpenDatabasesTool,
+		currentDatabaseTool,
+		selectedRecordsTool,
+		listGroupContentTool,
+		getRecordContentTool,
+		renameRecordTool,
+		addTagsTool,
+		removeTagsTool,
+		classifyTool,
+		compareTool,
+		replicateRecordTool,
+		duplicateRecordTool,
+		convertRecordTool,
+		updateRecordContentTool,
+	];
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools };
-  });
+	server.setRequestHandler(ListToolsRequestSchema, async () => {
+		return { tools };
+	});
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return { resources: [] };
-  });
+	server.setRequestHandler(ListResourcesRequestSchema, async () => {
+		return { resources: [] };
+	});
 
-  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    return { resources: [] };
-  });
+	server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+		return { resources: [] };
+	});
 
-  server.setRequestHandler(ListPromptsRequestSchema, async () => {
-    return { prompts: [] };
-  });
+	server.setRequestHandler(ListPromptsRequestSchema, async () => {
+		return { prompts: [] };
+	});
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args = {} } = request.params;
+	server.setRequestHandler(CallToolRequestSchema, async (request) => {
+		const { name, arguments: args = {} } = request.params;
 
-    const tool = tools.find((t) => t.name === name);
+		const tool = tools.find((t) => t.name === name);
 
-    if (!tool) {
-      throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
-    }
+		if (!tool) {
+			throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+		}
 
-    if (typeof tool.run !== "function") {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Tool '${name}' has no run function.`
-      );
-    }
+		if (typeof tool.run !== "function") {
+			throw new McpError(ErrorCode.InternalError, `Tool '${name}' has no run function.`);
+		}
 
-    try {
-      const result = await tool.run(args);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw error instanceof McpError
-        ? error
-        : new McpError(
-            ErrorCode.InternalError,
-            error instanceof Error ? error.message : String(error)
-          );
-    }
-  });
+		try {
+			const result = await tool.run(args);
+			return {
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(result, null, 2),
+					},
+				],
+			};
+		} catch (error) {
+			throw error instanceof McpError
+				? error
+				: new McpError(
+						ErrorCode.InternalError,
+						error instanceof Error ? error.message : String(error),
+					);
+		}
+	});
 
-  return { server, cleanup: async () => {} };
+	return { server, cleanup: async () => {} };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,20 +4,20 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createServer } from "./devonthink.js";
 
 async function main() {
-  const transport = new StdioServerTransport();
-  const { server, cleanup } = await createServer();
+	const transport = new StdioServerTransport();
+	const { server, cleanup } = await createServer();
 
-  await server.connect(transport);
+	await server.connect(transport);
 
-  // Cleanup on exit
-  process.on("SIGINT", async () => {
-    await cleanup();
-    await server.close();
-    process.exit(0);
-  });
+	// Cleanup on exit
+	process.on("SIGINT", async () => {
+		await cleanup();
+		await server.close();
+		process.exit(0);
+	});
 }
 
 main().catch((error) => {
-  console.error("Server error:", error);
-  process.exit(1);
+	console.error("Server error:", error);
+	process.exit(1);
 });

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -3,34 +3,34 @@ import express from "express";
 import { createServer } from "./devonthink.js";
 
 async function main() {
-    const app = express();
+	const app = express();
 
-    const { server, cleanup } = await createServer();
+	const { server, cleanup } = await createServer();
 
-    let transport: SSEServerTransport;
+	let transport: SSEServerTransport;
 
-    app.get("/sse", async (req, res) => {
-      console.log("Received connection");
-      transport = new SSEServerTransport("/message", res);
-      await server.connect(transport);
+	app.get("/sse", async (req, res) => {
+		console.log("Received connection");
+		transport = new SSEServerTransport("/message", res);
+		await server.connect(transport);
 
-      server.onclose = async () => {
-        await cleanup();
-        await server.close();
-        process.exit(0);
-      };
-    });
+		server.onclose = async () => {
+			await cleanup();
+			await server.close();
+			process.exit(0);
+		};
+	});
 
-    app.post("/message", async (req, res) => {
-      console.log("Received message");
+	app.post("/message", async (req, res) => {
+		console.log("Received message");
 
-      await transport.handlePostMessage(req, res);
-    });
+		await transport.handlePostMessage(req, res);
+	});
 
-    const PORT = process.env.PORT || 3001;
-    app.listen(PORT, () => {
-      console.log(`Server is running on port ${PORT}`);
-    });
+	const PORT = process.env.PORT || 3001;
+	app.listen(PORT, () => {
+		console.log(`Server is running on port ${PORT}`);
+	});
 }
 
 main();

--- a/src/tools/addTags.ts
+++ b/src/tools/addTags.ts
@@ -2,44 +2,40 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const AddTagsSchema = z
-  .object({
-    uuid: z.string().describe("The UUID of the record to add tags to"),
-    tags: z.array(z.string()).describe("An array of tags to add"),
-  })
-  .strict();
+	.object({
+		uuid: z.string().describe("The UUID of the record to add tags to"),
+		tags: z.array(z.string()).describe("An array of tags to add"),
+	})
+	.strict();
 
 type AddTagsInput = z.infer<typeof AddTagsSchema>;
 
 interface AddTagsResult {
-  success: boolean;
-  error?: string;
+	success: boolean;
+	error?: string;
 }
 
 const addTags = async (input: AddTagsInput): Promise<AddTagsResult> => {
-  const { uuid, tags } = input;
+	const { uuid, tags } = input;
 
-  // Validate string inputs
-  if (!isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  for (const tag of tags) {
-    if (!isJXASafeString(tag)) {
-      return { success: false, error: `Tag "${tag}" contains invalid characters` };
-    }
-  }
+	// Validate string inputs
+	if (!isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	for (const tag of tags) {
+		if (!isJXASafeString(tag)) {
+			return { success: false, error: `Tag "${tag}" contains invalid characters` };
+		}
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -78,12 +74,12 @@ const addTags = async (input: AddTagsInput): Promise<AddTagsResult> => {
     })();
   `;
 
-  return await executeJxa<AddTagsResult>(script);
+	return await executeJxa<AddTagsResult>(script);
 };
 
 export const addTagsTool: Tool = {
-  name: "add_tags",
-  description: "Adds tags to a specific record in DEVONthink.",
-  inputSchema: zodToJsonSchema(AddTagsSchema) as ToolInput,
-  run: addTags,
+	name: "add_tags",
+	description: "Adds tags to a specific record in DEVONthink.",
+	inputSchema: zodToJsonSchema(AddTagsSchema) as ToolInput,
+	run: addTags,
 };

--- a/src/tools/createFromUrl.ts
+++ b/src/tools/createFromUrl.ts
@@ -7,82 +7,70 @@ const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const CreateFromUrlSchema = z
-  .object({
-    url: z.string().url().describe("The URL to create a record from"),
-    format: z
-      .enum(["formatted_note", "markdown", "pdf", "web_document"])
-      .describe("The format to create the record in"),
-    name: z
-      .string()
-      .optional()
-      .describe("Custom name for the record (auto-generated if not provided)"),
-    parentGroupUuid: z
-      .string()
-      .optional()
-      .describe(
-        "The UUID of the parent group (defaults to the database's incoming group)"
-      ),
-    readability: z
-      .boolean()
-      .optional()
-      .describe(
-        "Whether to use readability mode to declutter the page (default: false)"
-      ),
-    userAgent: z
-      .string()
-      .optional()
-      .describe("Custom user agent string to use for the request"),
-    referrer: z
-      .string()
-      .optional()
-      .describe("HTTP referrer to use for the request"),
-    pdfOptions: z
-      .object({
-        pagination: z
-          .boolean()
-          .optional()
-          .describe("Whether to paginate the PDF"),
-        width: z.number().optional().describe("Width for PDF in points"),
-      })
-      .optional()
-      .describe("PDF-specific options (only used when format is 'pdf')"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to create the record in (defaults to current database)"
-      ),
-  })
-  .strict();
+	.object({
+		url: z.string().url().describe("The URL to create a record from"),
+		format: z
+			.enum(["formatted_note", "markdown", "pdf", "web_document"])
+			.describe("The format to create the record in"),
+		name: z
+			.string()
+			.optional()
+			.describe("Custom name for the record (auto-generated if not provided)"),
+		parentGroupUuid: z
+			.string()
+			.optional()
+			.describe("The UUID of the parent group (defaults to the database's incoming group)"),
+		readability: z
+			.boolean()
+			.optional()
+			.describe("Whether to use readability mode to declutter the page (default: false)"),
+		userAgent: z
+			.string()
+			.optional()
+			.describe("Custom user agent string to use for the request"),
+		referrer: z.string().optional().describe("HTTP referrer to use for the request"),
+		pdfOptions: z
+			.object({
+				pagination: z.boolean().optional().describe("Whether to paginate the PDF"),
+				width: z.number().optional().describe("Width for PDF in points"),
+			})
+			.optional()
+			.describe("PDF-specific options (only used when format is 'pdf')"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database to create the record in (defaults to current database)",
+			),
+	})
+	.strict();
 
 type CreateFromUrlInput = z.infer<typeof CreateFromUrlSchema>;
 
 interface CreateFromUrlResult {
-  success: boolean;
-  error?: string;
-  recordId?: number;
-  name?: string;
-  path?: string;
-  location?: string;
-  uuid?: string;
+	success: boolean;
+	error?: string;
+	recordId?: number;
+	name?: string;
+	path?: string;
+	location?: string;
+	uuid?: string;
 }
 
-const createFromUrl = async (
-  input: CreateFromUrlInput
-): Promise<CreateFromUrlResult> => {
-  const {
-    url,
-    format,
-    name,
-    parentGroupUuid,
-    readability,
-    userAgent,
-    referrer,
-    pdfOptions,
-    databaseName,
-  } = input;
+const createFromUrl = async (input: CreateFromUrlInput): Promise<CreateFromUrlResult> => {
+	const {
+		url,
+		format,
+		name,
+		parentGroupUuid,
+		readability,
+		userAgent,
+		referrer,
+		pdfOptions,
+		databaseName,
+	} = input;
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -120,17 +108,13 @@ const createFromUrl = async (
         
         // Add PDF-specific options if provided
         ${
-          pdfOptions && format === "pdf"
-            ? `
-          ${
-            pdfOptions.pagination
-              ? `options.pagination = ${pdfOptions.pagination};`
-              : ""
-          }
+			pdfOptions && format === "pdf"
+				? `
+          ${pdfOptions.pagination ? `options.pagination = ${pdfOptions.pagination};` : ""}
           ${pdfOptions.width ? `options.width = ${pdfOptions.width};` : ""}
         `
-            : ""
-        }
+				: ""
+		}
         
         let newRecord;
         
@@ -179,13 +163,13 @@ const createFromUrl = async (
     })();
   `;
 
-  return await executeJxa<CreateFromUrlResult>(script);
+	return await executeJxa<CreateFromUrlResult>(script);
 };
 
 export const createFromUrlTool: Tool = {
-  name: "create_from_url",
-  description:
-    "Create a record in DEVONthink from a web URL. This tool supports creating formatted notes, markdown, PDFs, and web documents. Use `parentGroupUuid` to specify a location, otherwise it will be created in the database's incoming group. The tool returns the `uuid` of the new record.\n\nIMPORTANT - Database Root vs Inbox:\n- No parentGroupUuid = creates in database's Inbox (incoming group)\n- To create at database root: use parentGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root creation:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use create_from_url with parentGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
-  inputSchema: zodToJsonSchema(CreateFromUrlSchema) as ToolInput,
-  run: createFromUrl,
+	name: "create_from_url",
+	description:
+		"Create a record in DEVONthink from a web URL. This tool supports creating formatted notes, markdown, PDFs, and web documents. Use `parentGroupUuid` to specify a location, otherwise it will be created in the database's incoming group. The tool returns the `uuid` of the new record.\n\nIMPORTANT - Database Root vs Inbox:\n- No parentGroupUuid = creates in database's Inbox (incoming group)\n- To create at database root: use parentGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root creation:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use create_from_url with parentGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
+	inputSchema: zodToJsonSchema(CreateFromUrlSchema) as ToolInput,
+	run: createFromUrl,
 };

--- a/src/tools/createRecord.ts
+++ b/src/tools/createRecord.ts
@@ -7,47 +7,43 @@ const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const CreateRecordSchema = z
-  .object({
-    name: z.string().describe("The name of the record to create"),
-    type: z
-      .string()
-      .describe(
-        "The record type (e.g., 'markdown', 'formatted note', 'bookmark', 'group')"
-      ),
-    content: z
-      .string()
-      .optional()
-      .describe("The content of the record (for text-based records)"),
-    url: z.string().optional().describe("The URL for bookmark records"),
-    parentGroupUuid: z
-      .string()
-      .optional()
-      .describe(
-        "The UUID of the parent group (defaults to the database's incoming group)"
-      ),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to create the record in (defaults to current database)"
-      ),
-  })
-  .strict();
+	.object({
+		name: z.string().describe("The name of the record to create"),
+		type: z
+			.string()
+			.describe("The record type (e.g., 'markdown', 'formatted note', 'bookmark', 'group')"),
+		content: z
+			.string()
+			.optional()
+			.describe("The content of the record (for text-based records)"),
+		url: z.string().optional().describe("The URL for bookmark records"),
+		parentGroupUuid: z
+			.string()
+			.optional()
+			.describe("The UUID of the parent group (defaults to the database's incoming group)"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database to create the record in (defaults to current database)",
+			),
+	})
+	.strict();
 
 type CreateRecordInput = z.infer<typeof CreateRecordSchema>;
 
 const createRecord = async (
-  input: CreateRecordInput
+	input: CreateRecordInput,
 ): Promise<{
-  success: boolean;
-  recordId?: number;
-  name?: string;
-  uuid?: string;
-  error?: string;
+	success: boolean;
+	recordId?: number;
+	name?: string;
+	uuid?: string;
+	error?: string;
 }> => {
-  const { name, type, content, url, parentGroupUuid, databaseName } = input;
+	const { name, type, content, url, parentGroupUuid, databaseName } = input;
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -82,11 +78,7 @@ const createRecord = async (
         };
         
         // Add content if provided
-        ${
-          content
-            ? `recordProps.content = \`${content.replace(/`/g, "\\`")}\`;`
-            : ""
-        }
+        ${content ? `recordProps.content = \`${content.replace(/`/g, "\\`")}\`;` : ""}
         
         // Add URL if provided
         ${url ? `recordProps.URL = "${url}";` : ""}
@@ -116,19 +108,19 @@ const createRecord = async (
     })();
   `;
 
-  return await executeJxa<{
-    success: boolean;
-    recordId?: number;
-    name?: string;
-    uuid?: string;
-    error?: string;
-  }>(script);
+	return await executeJxa<{
+		success: boolean;
+		recordId?: number;
+		name?: string;
+		uuid?: string;
+		error?: string;
+	}>(script);
 };
 
 export const createRecordTool: Tool = {
-  name: "create_record",
-  description:
-    "Create a new record in DEVONthink. This tool can create various record types, including groups, markdown files, and bookmarks. Use the `parentGroupUuid` to specify a location, otherwise it will be created in the database's incoming group. The tool returns the `uuid` of the new record, which can be used in other tools.\n\nIMPORTANT - Database Root vs Inbox:\n- No parentGroupUuid = creates in database's Inbox (incoming group)\n- To create at database root: use parentGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root creation:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use create_record with parentGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
-  inputSchema: zodToJsonSchema(CreateRecordSchema) as ToolInput,
-  run: createRecord,
+	name: "create_record",
+	description:
+		"Create a new record in DEVONthink. This tool can create various record types, including groups, markdown files, and bookmarks. Use the `parentGroupUuid` to specify a location, otherwise it will be created in the database's incoming group. The tool returns the `uuid` of the new record, which can be used in other tools.\n\nIMPORTANT - Database Root vs Inbox:\n- No parentGroupUuid = creates in database's Inbox (incoming group)\n- To create at database root: use parentGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root creation:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use create_record with parentGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
+	inputSchema: zodToJsonSchema(CreateRecordSchema) as ToolInput,
+	run: createRecord,
 };

--- a/src/tools/duplicateRecord.ts
+++ b/src/tools/duplicateRecord.ts
@@ -2,102 +2,91 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
-import {
-  getRecordLookupHelpers,
-  getDatabaseHelper,
-  isGroupHelper,
-} from "../utils/jxaHelpers.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
+import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const DuplicateRecordSchema = z
-  .object({
-    uuid: z.string().optional().describe("The UUID of the record to duplicate"),
-    recordId: z.number().optional().describe("The ID of the record to duplicate"),
-    recordPath: z
-      .string()
-      .optional()
-      .describe("The DEVONthink location path of the record (e.g., '/Inbox/My Document'), NOT the filesystem path"),
-    destinationGroupUuid: z
-      .string()
-      .describe("The UUID of the destination group (can be in any database)"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database containing the source record (defaults to current database)"
-      ),
-  })
-  .strict()
-  .refine(
-    (data) =>
-      data.uuid !== undefined ||
-      data.recordId !== undefined ||
-      data.recordPath !== undefined,
-    {
-      message:
-        "Either uuid, recordId, or recordPath must be provided",
-    }
-  );
+	.object({
+		uuid: z.string().optional().describe("The UUID of the record to duplicate"),
+		recordId: z.number().optional().describe("The ID of the record to duplicate"),
+		recordPath: z
+			.string()
+			.optional()
+			.describe(
+				"The DEVONthink location path of the record (e.g., '/Inbox/My Document'), NOT the filesystem path",
+			),
+		destinationGroupUuid: z
+			.string()
+			.describe("The UUID of the destination group (can be in any database)"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database containing the source record (defaults to current database)",
+			),
+	})
+	.strict()
+	.refine(
+		(data) =>
+			data.uuid !== undefined || data.recordId !== undefined || data.recordPath !== undefined,
+		{
+			message: "Either uuid, recordId, or recordPath must be provided",
+		},
+	);
 
 type DuplicateRecordInput = z.infer<typeof DuplicateRecordSchema>;
 
 interface DuplicateRecordResult {
-  success: boolean;
-  error?: string;
-  duplicatedRecord?: {
-    id: number;
-    uuid: string;
-    name: string;
-    path: string;
-    location: string;
-    recordType: string;
-    databaseName: string;
-  };
+	success: boolean;
+	error?: string;
+	duplicatedRecord?: {
+		id: number;
+		uuid: string;
+		name: string;
+		path: string;
+		location: string;
+		recordType: string;
+		databaseName: string;
+	};
 }
 
-const duplicateRecord = async (
-  input: DuplicateRecordInput
-): Promise<DuplicateRecordResult> => {
-  const uuid = input.uuid;
-  const recordId = input.recordId;
-  const recordPath = input.recordPath;
-  const destinationGroupUuid = input.destinationGroupUuid;
-  const databaseName = input.databaseName;
+const duplicateRecord = async (input: DuplicateRecordInput): Promise<DuplicateRecordResult> => {
+	const uuid = input.uuid;
+	const recordId = input.recordId;
+	const recordPath = input.recordPath;
+	const destinationGroupUuid = input.destinationGroupUuid;
+	const databaseName = input.databaseName;
 
-  // Validate string inputs
-  if (uuid && !isJXASafeString(uuid)) {
-    const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
-    errorResult["success"] = false;
-    errorResult["error"] = "UUID contains invalid characters";
-    return errorResult;
-  }
-  if (recordPath && !isJXASafeString(recordPath)) {
-    const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
-    errorResult["success"] = false;
-    errorResult["error"] = "Record path contains invalid characters";
-    return errorResult;
-  }
-  if (destinationGroupUuid && !isJXASafeString(destinationGroupUuid)) {
-    const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
-    errorResult["success"] = false;
-    errorResult["error"] = "Destination group UUID contains invalid characters";
-    return errorResult;
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
-    errorResult["success"] = false;
-    errorResult["error"] = "Database name contains invalid characters";
-    return errorResult;
-  }
+	// Validate string inputs
+	if (uuid && !isJXASafeString(uuid)) {
+		const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
+		errorResult["success"] = false;
+		errorResult["error"] = "UUID contains invalid characters";
+		return errorResult;
+	}
+	if (recordPath && !isJXASafeString(recordPath)) {
+		const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
+		errorResult["success"] = false;
+		errorResult["error"] = "Record path contains invalid characters";
+		return errorResult;
+	}
+	if (destinationGroupUuid && !isJXASafeString(destinationGroupUuid)) {
+		const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
+		errorResult["success"] = false;
+		errorResult["error"] = "Destination group UUID contains invalid characters";
+		return errorResult;
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		const errorResult: DuplicateRecordResult = {} as DuplicateRecordResult;
+		errorResult["success"] = false;
+		errorResult["error"] = "Database name contains invalid characters";
+		return errorResult;
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -201,13 +190,13 @@ const duplicateRecord = async (
     })();
   `;
 
-  return await executeJxa<DuplicateRecordResult>(script);
+	return await executeJxa<DuplicateRecordResult>(script);
 };
 
 export const duplicateRecordTool: Tool = {
-  name: "duplicate_record",
-  description:
-    "Duplicate a record to any destination group, creating an independent copy. Unlike replication, duplication can cross databases and creates a completely separate record. Indexed items are not supported by audit-proof databases.\n\nRecord identification methods (in order of reliability):\n1. **UUID** (recommended): Globally unique identifier that works across all databases\n2. **ID + Database**: Database-specific ID requires specifying the database name\n3. **DEVONthink Path**: Internal DEVONthink location path like '/Inbox/My Document' (NOT filesystem paths like '/Users/.../')\n\n**Important Path Note**: Use DEVONthink's internal location paths (shown in the 'Path' column in DEVONthink), not filesystem paths. Example: '/Projects/2024/Report.pdf' not '/Users/david/Databases/MyDB.dtBase2/Files.noindex/...'\n\n**Replicate vs Duplicate**:\n- **Replicate**: Creates linked reference within same database (use replicate_record tool)\n- **Duplicate**: Creates independent copy, can cross databases (this tool)\n\nReturns the duplicated record's UUID, ID, location, and destination database information.",
-  inputSchema: zodToJsonSchema(DuplicateRecordSchema) as ToolInput,
-  run: duplicateRecord,
+	name: "duplicate_record",
+	description:
+		"Duplicate a record to any destination group, creating an independent copy. Unlike replication, duplication can cross databases and creates a completely separate record. Indexed items are not supported by audit-proof databases.\n\nRecord identification methods (in order of reliability):\n1. **UUID** (recommended): Globally unique identifier that works across all databases\n2. **ID + Database**: Database-specific ID requires specifying the database name\n3. **DEVONthink Path**: Internal DEVONthink location path like '/Inbox/My Document' (NOT filesystem paths like '/Users/.../')\n\n**Important Path Note**: Use DEVONthink's internal location paths (shown in the 'Path' column in DEVONthink), not filesystem paths. Example: '/Projects/2024/Report.pdf' not '/Users/david/Databases/MyDB.dtBase2/Files.noindex/...'\n\n**Replicate vs Duplicate**:\n- **Replicate**: Creates linked reference within same database (use replicate_record tool)\n- **Duplicate**: Creates independent copy, can cross databases (this tool)\n\nReturns the duplicated record's UUID, ID, location, and destination database information.",
+	inputSchema: zodToJsonSchema(DuplicateRecordSchema) as ToolInput,
+	run: duplicateRecord,
 };

--- a/src/tools/getCurrentDatabase.ts
+++ b/src/tools/getCurrentDatabase.ts
@@ -9,27 +9,27 @@ type ToolInput = z.infer<typeof ToolInputSchema>;
 const GetCurrentDatabaseSchema = z.object({}).strict();
 
 interface DatabaseInfo {
-  id: number;
-  uuid: string;
-  name: string;
-  path: string;
-  filename: string;
-  encrypted: boolean;
-  auditProof: boolean;
-  readOnly: boolean;
-  spotlightIndexing: boolean;
-  versioning: boolean;
-  comment?: string;
+	id: number;
+	uuid: string;
+	name: string;
+	path: string;
+	filename: string;
+	encrypted: boolean;
+	auditProof: boolean;
+	readOnly: boolean;
+	spotlightIndexing: boolean;
+	versioning: boolean;
+	comment?: string;
 }
 
 interface GetCurrentDatabaseResult {
-  success: boolean;
-  error?: string;
-  database?: DatabaseInfo;
+	success: boolean;
+	error?: string;
+	database?: DatabaseInfo;
 }
 
 const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -75,13 +75,13 @@ const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
     })();
   `;
 
-  return await executeJxa<GetCurrentDatabaseResult>(script);
+	return await executeJxa<GetCurrentDatabaseResult>(script);
 };
 
 export const currentDatabaseTool: Tool = {
-  name: "current_database",
-  description:
-    "Get information about the currently selected/active database in DEVONthink. This tool returns detailed properties of the database that is currently in focus, including its UUID, name, path, and various settings. Useful for determining which database operations will target by default.",
-  inputSchema: zodToJsonSchema(GetCurrentDatabaseSchema) as ToolInput,
-  run: getCurrentDatabase,
+	name: "current_database",
+	description:
+		"Get information about the currently selected/active database in DEVONthink. This tool returns detailed properties of the database that is currently in focus, including its UUID, name, path, and various settings. Useful for determining which database operations will target by default.",
+	inputSchema: zodToJsonSchema(GetCurrentDatabaseSchema) as ToolInput,
+	run: getCurrentDatabase,
 };

--- a/src/tools/getOpenDatabases.ts
+++ b/src/tools/getOpenDatabases.ts
@@ -9,28 +9,28 @@ type ToolInput = z.infer<typeof ToolInputSchema>;
 const GetOpenDatabasesSchema = z.object({}).strict();
 
 interface DatabaseInfo {
-  id: number;
-  uuid: string;
-  name: string;
-  path: string;
-  filename: string;
-  encrypted: boolean;
-  auditProof: boolean;
-  readOnly: boolean;
-  spotlightIndexing: boolean;
-  versioning: boolean;
-  comment?: string;
+	id: number;
+	uuid: string;
+	name: string;
+	path: string;
+	filename: string;
+	encrypted: boolean;
+	auditProof: boolean;
+	readOnly: boolean;
+	spotlightIndexing: boolean;
+	versioning: boolean;
+	comment?: string;
 }
 
 interface GetOpenDatabasesResult {
-  success: boolean;
-  error?: string;
-  databases?: DatabaseInfo[];
-  totalCount?: number;
+	success: boolean;
+	error?: string;
+	databases?: DatabaseInfo[];
+	totalCount?: number;
 }
 
 const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -82,13 +82,13 @@ const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
     })();
   `;
 
-  return await executeJxa<GetOpenDatabasesResult>(script);
+	return await executeJxa<GetOpenDatabasesResult>(script);
 };
 
 export const getOpenDatabasesTool: Tool = {
-  name: "get_open_databases",
-  description:
-    "Get a list of all currently open databases in DEVONthink. This tool is useful for discovering available databases and their properties, such as name, path, and encryption status. The returned database names can be used in other tools.\n\nIMPORTANT - Database UUIDs for Claude Code Operations:\nThe UUID field in the results is ESSENTIAL for database root operations:\n- Use the database UUID as parentGroupUuid in create_record to create at database root\n- Use the database UUID as destinationGroupUuid in move_record to move to database root\n- Use the database UUID as parentGroupUuid in create_from_url to create at database root\n\nExample: Database UUID '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1' represents the true root level of that database.",
-  inputSchema: zodToJsonSchema(GetOpenDatabasesSchema) as ToolInput,
-  run: getOpenDatabases,
+	name: "get_open_databases",
+	description:
+		"Get a list of all currently open databases in DEVONthink. This tool is useful for discovering available databases and their properties, such as name, path, and encryption status. The returned database names can be used in other tools.\n\nIMPORTANT - Database UUIDs for Claude Code Operations:\nThe UUID field in the results is ESSENTIAL for database root operations:\n- Use the database UUID as parentGroupUuid in create_record to create at database root\n- Use the database UUID as destinationGroupUuid in move_record to move to database root\n- Use the database UUID as parentGroupUuid in create_from_url to create at database root\n\nExample: Database UUID '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1' represents the true root level of that database.",
+	inputSchema: zodToJsonSchema(GetOpenDatabasesSchema) as ToolInput,
+	run: getOpenDatabases,
 };

--- a/src/tools/getRecordByIdentifier.ts
+++ b/src/tools/getRecordByIdentifier.ts
@@ -2,76 +2,71 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const GetRecordByIdentifierSchema = z
-  .object({
-    uuid: z
-      .string()
-      .optional()
-      .describe("The UUID of the record (globally unique, works across all databases)"),
-    id: z
-      .number()
-      .optional()
-      .describe("The ID of the record (database-specific, requires databaseName)"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe("The name of the database (required when using ID, optional with UUID)"),
-  })
-  .strict()
-  .refine(
-    (data) => data.uuid !== undefined || (data.id !== undefined && data.databaseName !== undefined),
-    {
-      message: "Either UUID alone, or ID with databaseName must be provided",
-    }
-  );
+	.object({
+		uuid: z
+			.string()
+			.optional()
+			.describe("The UUID of the record (globally unique, works across all databases)"),
+		id: z
+			.number()
+			.optional()
+			.describe("The ID of the record (database-specific, requires databaseName)"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe("The name of the database (required when using ID, optional with UUID)"),
+	})
+	.strict()
+	.refine(
+		(data) =>
+			data.uuid !== undefined || (data.id !== undefined && data.databaseName !== undefined),
+		{
+			message: "Either UUID alone, or ID with databaseName must be provided",
+		},
+	);
 
 type GetRecordByIdentifierInput = z.infer<typeof GetRecordByIdentifierSchema>;
 
 interface RecordResult {
-  success: boolean;
-  error?: string;
-  record?: {
-    id: number;
-    uuid: string;
-    name: string;
-    path: string;
-    location: string;
-    recordType: string;
-    kind: string;
-    database: string;
-    creationDate?: string;
-    modificationDate?: string;
-    tags?: string[];
-    size?: number;
-    url?: string;
-    comment?: string;
-  };
+	success: boolean;
+	error?: string;
+	record?: {
+		id: number;
+		uuid: string;
+		name: string;
+		path: string;
+		location: string;
+		recordType: string;
+		kind: string;
+		database: string;
+		creationDate?: string;
+		modificationDate?: string;
+		tags?: string[];
+		size?: number;
+		url?: string;
+		comment?: string;
+	};
 }
 
-const getRecordByIdentifier = async (
-  input: GetRecordByIdentifierInput
-): Promise<RecordResult> => {
-  const { uuid, id, databaseName } = input;
+const getRecordByIdentifier = async (input: GetRecordByIdentifierInput): Promise<RecordResult> => {
+	const { uuid, id, databaseName } = input;
 
-  // Validate string inputs
-  if (uuid && !isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return { success: false, error: "Database name contains invalid characters" };
-  }
+	// Validate string inputs
+	if (uuid && !isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return { success: false, error: "Database name contains invalid characters" };
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -163,13 +158,13 @@ const getRecordByIdentifier = async (
     })();
   `;
 
-  return await executeJxa<RecordResult>(script);
+	return await executeJxa<RecordResult>(script);
 };
 
 export const getRecordByIdentifierTool: Tool = {
-  name: "get_record_by_identifier",
-  description:
-    "Get a DEVONthink record using either its UUID or ID+Database combination. This is the recommended tool for looking up specific records when you have their identifier.\n\n**UUID Lookup** (Recommended):\n- Globally unique across all databases\n- Works without specifying database\n- Most reliable method\n- Example: `uuid: '4A0C305D-2190-44F5-8E41-FB5E48ADEA2F'`\n\n**ID + Database Lookup**:\n- Requires both ID and database name\n- ID is only unique within a database\n- Example: `id: 12345, databaseName: '1 - Documents'`\n\nThis tool returns essential record properties including both UUID and ID for future reference. For full record properties, use get_record_properties with the returned UUID.",
-  inputSchema: zodToJsonSchema(GetRecordByIdentifierSchema) as ToolInput,
-  run: getRecordByIdentifier,
+	name: "get_record_by_identifier",
+	description:
+		"Get a DEVONthink record using either its UUID or ID+Database combination. This is the recommended tool for looking up specific records when you have their identifier.\n\n**UUID Lookup** (Recommended):\n- Globally unique across all databases\n- Works without specifying database\n- Most reliable method\n- Example: `uuid: '4A0C305D-2190-44F5-8E41-FB5E48ADEA2F'`\n\n**ID + Database Lookup**:\n- Requires both ID and database name\n- ID is only unique within a database\n- Example: `id: 12345, databaseName: '1 - Documents'`\n\nThis tool returns essential record properties including both UUID and ID for future reference. For full record properties, use get_record_properties with the returned UUID.",
+	inputSchema: zodToJsonSchema(GetRecordByIdentifierSchema) as ToolInput,
+	run: getRecordByIdentifier,
 };

--- a/src/tools/getRecordContent.ts
+++ b/src/tools/getRecordContent.ts
@@ -2,48 +2,42 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const GetRecordContentSchema = z
-  .object({
-    uuid: z.string().describe("The UUID of the record to get content from"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe("The name of the database to get the record from (optional)"),
-  })
-  .strict();
+	.object({
+		uuid: z.string().describe("The UUID of the record to get content from"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe("The name of the database to get the record from (optional)"),
+	})
+	.strict();
 
 type GetRecordContentInput = z.infer<typeof GetRecordContentSchema>;
 
 interface GetRecordContentResult {
-  success: boolean;
-  error?: string;
-  content?: string;
+	success: boolean;
+	error?: string;
+	content?: string;
 }
 
-const getRecordContent = async (
-  input: GetRecordContentInput
-): Promise<GetRecordContentResult> => {
-  const { uuid, databaseName } = input;
+const getRecordContent = async (input: GetRecordContentInput): Promise<GetRecordContentResult> => {
+	const { uuid, databaseName } = input;
 
-  // Validate string inputs
-  if (!isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return { success: false, error: "Database name contains invalid characters" };
-  }
+	// Validate string inputs
+	if (!isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return { success: false, error: "Database name contains invalid characters" };
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -101,12 +95,12 @@ const getRecordContent = async (
     })();
   `;
 
-  return await executeJxa<GetRecordContentResult>(script);
+	return await executeJxa<GetRecordContentResult>(script);
 };
 
 export const getRecordContentTool: Tool = {
-  name: "get_record_content",
-  description: "Gets the content of a specific record in DEVONthink.",
-  inputSchema: zodToJsonSchema(GetRecordContentSchema) as ToolInput,
-  run: getRecordContent,
+	name: "get_record_content",
+	description: "Gets the content of a specific record in DEVONthink.",
+	inputSchema: zodToJsonSchema(GetRecordContentSchema) as ToolInput,
+	run: getRecordContent,
 };

--- a/src/tools/getSelectedRecords.ts
+++ b/src/tools/getSelectedRecords.ts
@@ -9,31 +9,31 @@ type ToolInput = z.infer<typeof ToolInputSchema>;
 const GetSelectedRecordsSchema = z.object({}).strict();
 
 interface RecordInfo {
-  id: number;
-  uuid: string;
-  name: string;
-  path: string;
-  location: string;
-  recordType: string;
-  kind: string;
-  creationDate: string;
-  modificationDate: string;
-  tags: string[];
-  size: number;
-  rating?: number;
-  label?: number;
-  comment?: string;
+	id: number;
+	uuid: string;
+	name: string;
+	path: string;
+	location: string;
+	recordType: string;
+	kind: string;
+	creationDate: string;
+	modificationDate: string;
+	tags: string[];
+	size: number;
+	rating?: number;
+	label?: number;
+	comment?: string;
 }
 
 interface GetSelectedRecordsResult {
-  success: boolean;
-  error?: string;
-  records?: RecordInfo[];
-  totalCount?: number;
+	success: boolean;
+	error?: string;
+	records?: RecordInfo[];
+	totalCount?: number;
 }
 
 const getSelectedRecords = async (): Promise<GetSelectedRecordsResult> => {
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -94,13 +94,13 @@ const getSelectedRecords = async (): Promise<GetSelectedRecordsResult> => {
     })();
   `;
 
-  return await executeJxa<GetSelectedRecordsResult>(script);
+	return await executeJxa<GetSelectedRecordsResult>(script);
 };
 
 export const selectedRecordsTool: Tool = {
-  name: "selected_records",
-  description:
-    "Get information about currently selected records in DEVONthink. This tool returns detailed properties of all records that are currently selected in the DEVONthink interface, including their UUIDs, names, paths, types, and metadata. Returns an empty array if no records are selected. Useful for batch operations on user's current selection.",
-  inputSchema: zodToJsonSchema(GetSelectedRecordsSchema) as ToolInput,
-  run: getSelectedRecords,
+	name: "selected_records",
+	description:
+		"Get information about currently selected records in DEVONthink. This tool returns detailed properties of all records that are currently selected in the DEVONthink interface, including their UUIDs, names, paths, types, and metadata. Returns an empty array if no records are selected. Useful for batch operations on user's current selection.",
+	inputSchema: zodToJsonSchema(GetSelectedRecordsSchema) as ToolInput,
+	run: getSelectedRecords,
 };

--- a/src/tools/isRunning.ts
+++ b/src/tools/isRunning.ts
@@ -9,18 +9,18 @@ type ToolInput = z.infer<typeof ToolInputSchema>;
 const IsRunningSchema = z.object({}).strict();
 
 const isRunning = async (): Promise<{ isRunning: boolean }> => {
-  const script = `
+	const script = `
     const app = Application("DEVONthink");
     const isRunning = app.running();
     JSON.stringify({ isRunning });
   `;
-  return await executeJxa<{ isRunning: boolean }>(script);
+	return await executeJxa<{ isRunning: boolean }>(script);
 };
 
 export const isRunningTool: Tool = {
-  name: "is_running",
-  description:
-    "Check if the DEVONthink application is currently running. This is a simple check that returns a boolean value and is useful for verifying that the application is available before attempting other operations.",
-  inputSchema: zodToJsonSchema(IsRunningSchema) as ToolInput,
-  run: isRunning,
+	name: "is_running",
+	description:
+		"Check if the DEVONthink application is currently running. This is a simple check that returns a boolean value and is useful for verifying that the application is available before attempting other operations.",
+	inputSchema: zodToJsonSchema(IsRunningSchema) as ToolInput,
+	run: isRunning,
 };

--- a/src/tools/listGroupContent.ts
+++ b/src/tools/listGroupContent.ts
@@ -7,42 +7,40 @@ const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const ListGroupContentSchema = z
-  .object({
-    uuid: z
-      .string()
-      .optional()
-      .describe(
-        "The UUID of the group to list content from. Defaults to the root of the database if not provided or if '/' is passed."
-      ),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to get the record properties from (defaults to current database)"
-      ),
-  })
-  .strict();
+	.object({
+		uuid: z
+			.string()
+			.optional()
+			.describe(
+				"The UUID of the group to list content from. Defaults to the root of the database if not provided or if '/' is passed.",
+			),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database to get the record properties from (defaults to current database)",
+			),
+	})
+	.strict();
 
 type ListGroupContentInput = z.infer<typeof ListGroupContentSchema>;
 
 interface RecordInfo {
-  uuid: string;
-  name: string;
-  recordType: string;
+	uuid: string;
+	name: string;
+	recordType: string;
 }
 
 interface ListGroupContentResult {
-  success: boolean;
-  error?: string;
-  records?: RecordInfo[];
+	success: boolean;
+	error?: string;
+	records?: RecordInfo[];
 }
 
-const listGroupContent = async (
-  input: ListGroupContentInput
-): Promise<ListGroupContentResult> => {
-  const { uuid, databaseName } = input;
+const listGroupContent = async (input: ListGroupContentInput): Promise<ListGroupContentResult> => {
+	const { uuid, databaseName } = input;
 
-  const getDatabaseJxa = `
+	const getDatabaseJxa = `
     let targetDatabase;
     if ("${databaseName || ""}") {
       const databases = theApp.databases();
@@ -55,12 +53,12 @@ const listGroupContent = async (
     }
   `;
 
-  const getGroupJxa =
-    uuid && uuid !== "/"
-      ? `const group = theApp.getRecordWithUuid("${uuid}");`
-      : `const group = targetDatabase.root();`;
+	const getGroupJxa =
+		uuid && uuid !== "/"
+			? `const group = theApp.getRecordWithUuid("${uuid}");`
+			: `const group = targetDatabase.root();`;
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -104,13 +102,13 @@ const listGroupContent = async (
     })();
   `;
 
-  return await executeJxa<ListGroupContentResult>(script);
+	return await executeJxa<ListGroupContentResult>(script);
 };
 
 export const listGroupContentTool: Tool = {
-  name: "list_group_content",
-  description:
-    "Lists the content of a specific group in DEVONthink. If the uuid is not provided or is '/', it will list the content of the root group.",
-  inputSchema: zodToJsonSchema(ListGroupContentSchema) as ToolInput,
-  run: listGroupContent,
+	name: "list_group_content",
+	description:
+		"Lists the content of a specific group in DEVONthink. If the uuid is not provided or is '/', it will list the content of the root group.",
+	inputSchema: zodToJsonSchema(ListGroupContentSchema) as ToolInput,
+	run: listGroupContent,
 };

--- a/src/tools/lookupRecord.ts
+++ b/src/tools/lookupRecord.ts
@@ -7,71 +7,57 @@ const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const LookupRecordSchema = z
-  .object({
-    lookupType: z
-      .enum(["filename", "path", "url", "tags", "comment", "contentHash"])
-      .describe("The type of lookup to perform"),
-    value: z.string().describe("The value to search for"),
-    tags: z
-      .array(z.string())
-      .optional()
-      .describe(
-        "Array of tags to search for (only used when lookupType is 'tags')"
-      ),
-    matchAnyTag: z
-      .boolean()
-      .optional()
-      .describe(
-        "Whether to match any tag instead of all tags (only used when lookupType is 'tags')"
-      ),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to search in (searches current database if not provided)"
-      ),
-    limit: z
-      .number()
-      .optional()
-      .describe("Maximum number of results to return (default: 50)"),
-  })
-  .strict();
+	.object({
+		lookupType: z
+			.enum(["filename", "path", "url", "tags", "comment", "contentHash"])
+			.describe("The type of lookup to perform"),
+		value: z.string().describe("The value to search for"),
+		tags: z
+			.array(z.string())
+			.optional()
+			.describe("Array of tags to search for (only used when lookupType is 'tags')"),
+		matchAnyTag: z
+			.boolean()
+			.optional()
+			.describe(
+				"Whether to match any tag instead of all tags (only used when lookupType is 'tags')",
+			),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database to search in (searches current database if not provided)",
+			),
+		limit: z.number().optional().describe("Maximum number of results to return (default: 50)"),
+	})
+	.strict();
 
 type LookupRecordInput = z.infer<typeof LookupRecordSchema>;
 
 interface LookupResult {
-  success: boolean;
-  error?: string;
-  results?: Array<{
-    id: number;
-    name: string;
-    path: string;
-    location: string;
-    recordType: string;
-    kind: string;
-    creationDate?: string;
-    modificationDate?: string;
-    tags?: string[];
-    size?: number;
-    url?: string;
-    comment?: string;
-  }>;
-  totalCount?: number;
+	success: boolean;
+	error?: string;
+	results?: Array<{
+		id: number;
+		name: string;
+		path: string;
+		location: string;
+		recordType: string;
+		kind: string;
+		creationDate?: string;
+		modificationDate?: string;
+		tags?: string[];
+		size?: number;
+		url?: string;
+		comment?: string;
+	}>;
+	totalCount?: number;
 }
 
-const lookupRecord = async (
-  input: LookupRecordInput
-): Promise<LookupResult> => {
-  const {
-    lookupType,
-    value,
-    tags,
-    matchAnyTag,
-    databaseName,
-    limit = 50,
-  } = input;
+const lookupRecord = async (input: LookupRecordInput): Promise<LookupResult> => {
+	const { lookupType, value, tags, matchAnyTag, databaseName, limit = 50 } = input;
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -182,13 +168,13 @@ const lookupRecord = async (
     })();
   `;
 
-  return await executeJxa<LookupResult>(script);
+	return await executeJxa<LookupResult>(script);
 };
 
 export const lookupRecordTool: Tool = {
-  name: "lookup_record",
-  description:
-    "Look up records in DEVONthink by a specific attribute. This tool is ideal for finding records when you have an exact value to match, such as a filename, URL, or tag. It does not support wildcards or partial matches.\n\nExamples:\n- Find by filename: lookupType='filename', value='report.pdf'\n- Find by URL: lookupType='url', value='https://example.com'\n- Find by single tag: lookupType='tags', value='important' (or tags=['important'])\n- Find by multiple tags (all): lookupType='tags', tags=['work', 'project']\n- Find by multiple tags (any): lookupType='tags', tags=['work', 'project'], matchAnyTag=true\n- Find by path: lookupType='path', value='/Documents/Research'\n- Find by comment: lookupType='comment', value='Meeting notes'\n- Find by content hash: lookupType='contentHash', value='abc123...'\n\nFor tag lookups, you can either use the 'tags' parameter for an array of tags, or use the 'value' parameter for a single tag.",
-  inputSchema: zodToJsonSchema(LookupRecordSchema) as ToolInput,
-  run: lookupRecord,
+	name: "lookup_record",
+	description:
+		"Look up records in DEVONthink by a specific attribute. This tool is ideal for finding records when you have an exact value to match, such as a filename, URL, or tag. It does not support wildcards or partial matches.\n\nExamples:\n- Find by filename: lookupType='filename', value='report.pdf'\n- Find by URL: lookupType='url', value='https://example.com'\n- Find by single tag: lookupType='tags', value='important' (or tags=['important'])\n- Find by multiple tags (all): lookupType='tags', tags=['work', 'project']\n- Find by multiple tags (any): lookupType='tags', tags=['work', 'project'], matchAnyTag=true\n- Find by path: lookupType='path', value='/Documents/Research'\n- Find by comment: lookupType='comment', value='Meeting notes'\n- Find by content hash: lookupType='contentHash', value='abc123...'\n\nFor tag lookups, you can either use the 'tags' parameter for an array of tags, or use the 'value' parameter for a single tag.",
+	inputSchema: zodToJsonSchema(LookupRecordSchema) as ToolInput,
+	run: lookupRecord,
 };

--- a/src/tools/moveRecord.ts
+++ b/src/tools/moveRecord.ts
@@ -2,94 +2,75 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
-import {
-  getRecordLookupHelpers,
-  getDatabaseHelper,
-  isGroupHelper,
-} from "../utils/jxaHelpers.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
+import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const MoveRecordSchema = z
-  .object({
-    uuid: z.string().optional().describe("The UUID of the record"),
-    recordId: z.number().optional().describe("The ID of the record to move"),
-    recordName: z
-      .string()
-      .optional()
-      .describe("The name of the record to move (if ID not provided)"),
-    recordPath: z
-      .string()
-      .optional()
-      .describe("The path of the record to move (if ID not provided)"),
-    destinationGroupUuid: z
-      .string()
-      .optional()
-      .describe("The UUID of the destination group"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to move the record in (defaults to current database)"
-      ),
-  })
-  .strict()
-  .refine(
-    (data) =>
-      data.uuid !== undefined ||
-      data.recordId !== undefined ||
-      data.recordName !== undefined ||
-      data.recordPath !== undefined,
-    {
-      message:
-        "Either uuid, recordId, recordName, or recordPath must be provided",
-    }
-  );
+	.object({
+		uuid: z.string().optional().describe("The UUID of the record"),
+		recordId: z.number().optional().describe("The ID of the record to move"),
+		recordName: z
+			.string()
+			.optional()
+			.describe("The name of the record to move (if ID not provided)"),
+		recordPath: z
+			.string()
+			.optional()
+			.describe("The path of the record to move (if ID not provided)"),
+		destinationGroupUuid: z.string().optional().describe("The UUID of the destination group"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"The name of the database to move the record in (defaults to current database)",
+			),
+	})
+	.strict()
+	.refine(
+		(data) =>
+			data.uuid !== undefined ||
+			data.recordId !== undefined ||
+			data.recordName !== undefined ||
+			data.recordPath !== undefined,
+		{
+			message: "Either uuid, recordId, recordName, or recordPath must be provided",
+		},
+	);
 
 type MoveRecordInput = z.infer<typeof MoveRecordSchema>;
 
 const moveRecord = async (
-  input: MoveRecordInput
+	input: MoveRecordInput,
 ): Promise<{ success: boolean; newLocation?: string; error?: string }> => {
-  const {
-    uuid,
-    recordId,
-    recordName,
-    recordPath,
-    destinationGroupUuid,
-    databaseName,
-  } = input;
+	const { uuid, recordId, recordName, recordPath, destinationGroupUuid, databaseName } = input;
 
-  // Validate string inputs
-  if (uuid && !isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  if (recordName && !isJXASafeString(recordName)) {
-    return { success: false, error: "Record name contains invalid characters" };
-  }
-  if (recordPath && !isJXASafeString(recordPath)) {
-    return { success: false, error: "Record path contains invalid characters" };
-  }
-  if (destinationGroupUuid && !isJXASafeString(destinationGroupUuid)) {
-    return {
-      success: false,
-      error: "Destination UUID contains invalid characters",
-    };
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return {
-      success: false,
-      error: "Database name contains invalid characters",
-    };
-  }
+	// Validate string inputs
+	if (uuid && !isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	if (recordName && !isJXASafeString(recordName)) {
+		return { success: false, error: "Record name contains invalid characters" };
+	}
+	if (recordPath && !isJXASafeString(recordPath)) {
+		return { success: false, error: "Record path contains invalid characters" };
+	}
+	if (destinationGroupUuid && !isJXASafeString(destinationGroupUuid)) {
+		return {
+			success: false,
+			error: "Destination UUID contains invalid characters",
+		};
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return {
+			success: false,
+			error: "Database name contains invalid characters",
+		};
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -102,8 +83,8 @@ const moveRecord = async (
       try {
         // Get target database
         const targetDatabase = getDatabase(theApp, ${
-          databaseName ? `"${escapeStringForJXA(databaseName)}"` : "null"
-        });
+			databaseName ? `"${escapeStringForJXA(databaseName)}"` : "null"
+		});
         
         // Build lookup options for the record to move
         const lookupOptions = {
@@ -133,10 +114,8 @@ const moveRecord = async (
         // Find the destination group
         let destinationGroupRecord;
         const pDestinationGroupUuid = ${
-          destinationGroupUuid
-            ? `"${escapeStringForJXA(destinationGroupUuid)}"`
-            : "null"
-        };
+			destinationGroupUuid ? `"${escapeStringForJXA(destinationGroupUuid)}"` : "null"
+		};
         
         if (pDestinationGroupUuid) {
           try {
@@ -189,17 +168,17 @@ const moveRecord = async (
     })();
   `;
 
-  return await executeJxa<{
-    success: boolean;
-    newLocation?: string;
-    error?: string;
-  }>(script);
+	return await executeJxa<{
+		success: boolean;
+		newLocation?: string;
+		error?: string;
+	}>(script);
 };
 
 export const moveRecordTool: Tool = {
-  name: "move_record",
-  description:
-    "Move a record to a different group in DEVONthink. It's highly recommended to use the `uuid` for the record and `destinationGroupUuid` for the destination to ensure accurate moving.\n\nIMPORTANT - Moving to Database Root:\n- Cannot use '/' as destinationGroupUuid (tool limitation)\n- To move to database root: use destinationGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root move:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use move_record with destinationGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
-  inputSchema: zodToJsonSchema(MoveRecordSchema) as ToolInput,
-  run: moveRecord,
+	name: "move_record",
+	description:
+		"Move a record to a different group in DEVONthink. It's highly recommended to use the `uuid` for the record and `destinationGroupUuid` for the destination to ensure accurate moving.\n\nIMPORTANT - Moving to Database Root:\n- Cannot use '/' as destinationGroupUuid (tool limitation)\n- To move to database root: use destinationGroupUuid with the database UUID\n- Get database UUID first using get_open_databases tool\n\nExample workflow for root move:\n1. Use get_open_databases to get database UUID (e.g., '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1')\n2. Use move_record with destinationGroupUuid: '5E47D6F2-5E0C-4E30-A6ED-2AC92116C3E1'",
+	inputSchema: zodToJsonSchema(MoveRecordSchema) as ToolInput,
+	run: moveRecord,
 };

--- a/src/tools/removeTags.ts
+++ b/src/tools/removeTags.ts
@@ -2,55 +2,47 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const RemoveTagsSchema = z
-  .object({
-    uuid: z.string().describe("The UUID of the record to remove tags from"),
-    tags: z.array(z.string()).describe("An array of tags to remove"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe(
-        "The name of the database to remove tags from the record in (optional)"
-      ),
-  })
-  .strict();
+	.object({
+		uuid: z.string().describe("The UUID of the record to remove tags from"),
+		tags: z.array(z.string()).describe("An array of tags to remove"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe("The name of the database to remove tags from the record in (optional)"),
+	})
+	.strict();
 
 type RemoveTagsInput = z.infer<typeof RemoveTagsSchema>;
 
 interface RemoveTagsResult {
-  success: boolean;
-  error?: string;
+	success: boolean;
+	error?: string;
 }
 
-const removeTags = async (
-  input: RemoveTagsInput
-): Promise<RemoveTagsResult> => {
-  const { uuid, tags, databaseName } = input;
+const removeTags = async (input: RemoveTagsInput): Promise<RemoveTagsResult> => {
+	const { uuid, tags, databaseName } = input;
 
-  // Validate string inputs
-  if (!isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  for (const tag of tags) {
-    if (!isJXASafeString(tag)) {
-      return { success: false, error: `Tag "${tag}" contains invalid characters` };
-    }
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return { success: false, error: "Database name contains invalid characters" };
-  }
+	// Validate string inputs
+	if (!isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	for (const tag of tags) {
+		if (!isJXASafeString(tag)) {
+			return { success: false, error: `Tag "${tag}" contains invalid characters` };
+		}
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return { success: false, error: "Database name contains invalid characters" };
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -101,12 +93,12 @@ const removeTags = async (
     })();
   `;
 
-  return await executeJxa<RemoveTagsResult>(script);
+	return await executeJxa<RemoveTagsResult>(script);
 };
 
 export const removeTagsTool: Tool = {
-  name: "remove_tags",
-  description: "Removes tags from a specific record in DEVONthink.",
-  inputSchema: zodToJsonSchema(RemoveTagsSchema) as ToolInput,
-  run: removeTags,
+	name: "remove_tags",
+	description: "Removes tags from a specific record in DEVONthink.",
+	inputSchema: zodToJsonSchema(RemoveTagsSchema) as ToolInput,
+	run: removeTags,
 };

--- a/src/tools/renameRecord.ts
+++ b/src/tools/renameRecord.ts
@@ -2,51 +2,45 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  formatValueForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const RenameRecordSchema = z
-  .object({
-    uuid: z.string().describe("The UUID of the record to rename"),
-    newName: z.string().describe("The new name for the record"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe("The name of the database to rename the record in (optional)"),
-  })
-  .strict();
+	.object({
+		uuid: z.string().describe("The UUID of the record to rename"),
+		newName: z.string().describe("The new name for the record"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe("The name of the database to rename the record in (optional)"),
+	})
+	.strict();
 
 type RenameRecordInput = z.infer<typeof RenameRecordSchema>;
 
 interface RenameRecordResult {
-  success: boolean;
-  error?: string;
+	success: boolean;
+	error?: string;
 }
 
-const renameRecord = async (
-  input: RenameRecordInput
-): Promise<RenameRecordResult> => {
-  const { uuid, newName, databaseName } = input;
+const renameRecord = async (input: RenameRecordInput): Promise<RenameRecordResult> => {
+	const { uuid, newName, databaseName } = input;
 
-  // Validate string inputs
-  if (!isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  if (!isJXASafeString(newName)) {
-    return { success: false, error: "New name contains invalid characters" };
-  }
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return { success: false, error: "Database name contains invalid characters" };
-  }
+	// Validate string inputs
+	if (!isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	if (!isJXASafeString(newName)) {
+		return { success: false, error: "New name contains invalid characters" };
+	}
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return { success: false, error: "Database name contains invalid characters" };
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -94,12 +88,12 @@ const renameRecord = async (
     })();
   `;
 
-  return await executeJxa<RenameRecordResult>(script);
+	return await executeJxa<RenameRecordResult>(script);
 };
 
 export const renameRecordTool: Tool = {
-  name: "rename_record",
-  description: "Renames a specific record in DEVONthink.",
-  inputSchema: zodToJsonSchema(RenameRecordSchema) as ToolInput,
-  run: renameRecord,
+	name: "rename_record",
+	description: "Renames a specific record in DEVONthink.",
+	inputSchema: zodToJsonSchema(RenameRecordSchema) as ToolInput,
+	run: renameRecord,
 };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3,168 +3,158 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import {
-  escapeSearchQuery,
-  formatValueForJXA,
-  isJXASafeString,
-  escapeStringForJXA,
+	escapeSearchQuery,
+	formatValueForJXA,
+	isJXASafeString,
+	escapeStringForJXA,
 } from "../utils/escapeString.js";
-import {
-  getRecordLookupHelpers,
-  getDatabaseHelper,
-  isGroupHelper,
-} from "../utils/jxaHelpers.js";
+import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const SearchSchema = z
-  .object({
-    query: z.string().describe("The search query string"),
-    groupUuid: z
-      .string()
-      .optional()
-      .describe("The UUID of the group to search in (most reliable method)"),
-    groupId: z
-      .number()
-      .optional()
-      .describe("The ID of the group to search in (requires databaseName)"),
-    groupPath: z
-      .string()
-      .optional()
-      .describe("The path of the group to search in (e.g., '/Trips/2025')"),
-    databaseName: z
-      .string()
-      .optional()
-      .describe("The database name (required when using groupId)"),
-    useCurrentGroup: z
-      .boolean()
-      .optional()
-      .describe(
-        "Search in the currently selected group in DEVONthink (ignores other group parameters)"
-      ),
-    recordType: z
-      .enum([
-        "group",
-        "markdown",
-        "PDF",
-        "bookmark",
-        "formatted note",
-        "txt",
-        "rtf",
-        "rtfd",
-        "webarchive",
-        "quicktime",
-        "picture",
-        "smart group",
-      ])
-      .optional()
-      .describe(
-        "Filter results by record type (e.g., 'PDF' for PDF files, 'group' for folders)"
-      ),
-    comparison: z
-      .enum(["no case", "no umlauts", "fuzzy", "related"])
-      .optional()
-      .describe("The comparison type for the search"),
-    excludeSubgroups: z
-      .boolean()
-      .optional()
-      .describe("Whether to exclude subgroups from the search"),
-    limit: z
-      .number()
-      .optional()
-      .describe("Maximum number of results to return (default: 50)"),
-  })
-  .strict()
-  .refine(
-    (data) => {
-      // If groupId is provided, databaseName must also be provided
-      if (data.groupId !== undefined && !data.databaseName) {
-        return false;
-      }
-      // If useCurrentGroup is true, other group parameters should not be provided
-      if (
-        data.useCurrentGroup &&
-        (data.groupUuid || data.groupId || data.groupPath)
-      ) {
-        return false;
-      }
-      return true;
-    },
-    {
-      message:
-        "databaseName is required when using groupId; when useCurrentGroup is true, other group parameters should not be provided",
-    }
-  );
+	.object({
+		query: z.string().describe("The search query string"),
+		groupUuid: z
+			.string()
+			.optional()
+			.describe("The UUID of the group to search in (most reliable method)"),
+		groupId: z
+			.number()
+			.optional()
+			.describe("The ID of the group to search in (requires databaseName)"),
+		groupPath: z
+			.string()
+			.optional()
+			.describe("The path of the group to search in (e.g., '/Trips/2025')"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe("The database name (required when using groupId)"),
+		useCurrentGroup: z
+			.boolean()
+			.optional()
+			.describe(
+				"Search in the currently selected group in DEVONthink (ignores other group parameters)",
+			),
+		recordType: z
+			.enum([
+				"group",
+				"markdown",
+				"PDF",
+				"bookmark",
+				"formatted note",
+				"txt",
+				"rtf",
+				"rtfd",
+				"webarchive",
+				"quicktime",
+				"picture",
+				"smart group",
+			])
+			.optional()
+			.describe(
+				"Filter results by record type (e.g., 'PDF' for PDF files, 'group' for folders)",
+			),
+		comparison: z
+			.enum(["no case", "no umlauts", "fuzzy", "related"])
+			.optional()
+			.describe("The comparison type for the search"),
+		excludeSubgroups: z
+			.boolean()
+			.optional()
+			.describe("Whether to exclude subgroups from the search"),
+		limit: z.number().optional().describe("Maximum number of results to return (default: 50)"),
+	})
+	.strict()
+	.refine(
+		(data) => {
+			// If groupId is provided, databaseName must also be provided
+			if (data.groupId !== undefined && !data.databaseName) {
+				return false;
+			}
+			// If useCurrentGroup is true, other group parameters should not be provided
+			if (data.useCurrentGroup && (data.groupUuid || data.groupId || data.groupPath)) {
+				return false;
+			}
+			return true;
+		},
+		{
+			message:
+				"databaseName is required when using groupId; when useCurrentGroup is true, other group parameters should not be provided",
+		},
+	);
 
 type SearchInput = z.infer<typeof SearchSchema>;
 
 interface SearchResult {
-  success: boolean;
-  error?: string;
-  results?: Array<{
-    id: number;
-    uuid: string;
-    name: string;
-    path: string;
-    location: string;
-    recordType: string;
-    kind: string;
-    score?: number;
-    creationDate?: string;
-    modificationDate?: string;
-    tags?: string[];
-    size?: number;
-  }>;
-  totalCount?: number;
+	success: boolean;
+	error?: string;
+	results?: Array<{
+		id: number;
+		uuid: string;
+		name: string;
+		path: string;
+		location: string;
+		recordType: string;
+		kind: string;
+		score?: number;
+		creationDate?: string;
+		modificationDate?: string;
+		tags?: string[];
+		size?: number;
+	}>;
+	totalCount?: number;
 }
 
 const search = async (input: SearchInput): Promise<SearchResult> => {
-  const {
-    query,
-    groupUuid,
-    groupId,
-    groupPath,
-    databaseName,
-    useCurrentGroup,
-    recordType,
-    comparison,
-    excludeSubgroups,
-    limit = 50,
-  } = input;
+	const {
+		query,
+		groupUuid,
+		groupId,
+		groupPath,
+		databaseName,
+		useCurrentGroup,
+		recordType,
+		comparison,
+		excludeSubgroups,
+		limit = 50,
+	} = input;
 
-  // Validate inputs
-  if (!isJXASafeString(query)) {
-    return {
-      success: false,
-      error: "Search query contains invalid characters",
-    };
-  }
+	// Validate inputs
+	if (!isJXASafeString(query)) {
+		return {
+			success: false,
+			error: "Search query contains invalid characters",
+		};
+	}
 
-  if (groupUuid && !isJXASafeString(groupUuid)) {
-    return {
-      success: false,
-      error: "Group UUID contains invalid characters",
-    };
-  }
+	if (groupUuid && !isJXASafeString(groupUuid)) {
+		return {
+			success: false,
+			error: "Group UUID contains invalid characters",
+		};
+	}
 
-  if (groupPath && !isJXASafeString(groupPath)) {
-    return {
-      success: false,
-      error: "Group path contains invalid characters",
-    };
-  }
+	if (groupPath && !isJXASafeString(groupPath)) {
+		return {
+			success: false,
+			error: "Group path contains invalid characters",
+		};
+	}
 
-  if (databaseName && !isJXASafeString(databaseName)) {
-    return {
-      success: false,
-      error: "Database name contains invalid characters",
-    };
-  }
+	if (databaseName && !isJXASafeString(databaseName)) {
+		return {
+			success: false,
+			error: "Database name contains invalid characters",
+		};
+	}
 
-  // Escape the search query
-  const escapedQuery = escapeSearchQuery(query);
+	// Escape the search query
+	const escapedQuery = escapeSearchQuery(query);
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -176,22 +166,14 @@ const search = async (input: SearchInput): Promise<SearchResult> => {
       
       try {
         // Define variables for lookup
-        const pGroupUuid = ${
-          groupUuid ? `"${escapeStringForJXA(groupUuid)}"` : "null"
-        };
+        const pGroupUuid = ${groupUuid ? `"${escapeStringForJXA(groupUuid)}"` : "null"};
         const pGroupId = ${groupId !== undefined ? groupId : "null"};
-        const pGroupPath = ${
-          groupPath ? `"${escapeStringForJXA(groupPath)}"` : "null"
-        };
-        const pDatabaseName = ${
-          databaseName ? `"${escapeStringForJXA(databaseName)}"` : "null"
-        };
+        const pGroupPath = ${groupPath ? `"${escapeStringForJXA(groupPath)}"` : "null"};
+        const pDatabaseName = ${databaseName ? `"${escapeStringForJXA(databaseName)}"` : "null"};
         const pUseCurrentGroup = ${useCurrentGroup === true};
         const pRecordType = ${formatValueForJXA(recordType)};
         const pComparison = ${formatValueForJXA(comparison)};
-        const pExcludeSubgroups = ${
-          excludeSubgroups !== undefined ? excludeSubgroups : "null"
-        };
+        const pExcludeSubgroups = ${excludeSubgroups !== undefined ? excludeSubgroups : "null"};
         const pLimit = ${limit};
 
 
@@ -333,14 +315,13 @@ const search = async (input: SearchInput): Promise<SearchResult> => {
     })();
   `;
 
-
-  return await executeJxa<SearchResult>(script);
+	return await executeJxa<SearchResult>(script);
 };
 
 export const searchTool: Tool = {
-  name: "search",
-  description:
-    "Search for records in DEVONthink. This tool is useful for general text-based queries and can be scoped to a specific group. It supports various comparison options and returns a list of matching records with their properties including both ID and UUID.\n\n**Search query syntax examples:**\n- Simple text: `invoice 2024`\n- Boolean operators: `travel AND (berlin OR munich)`, `invoice NOT paid`\n- Exact phrase: `\"exact phrase here\"`\n- Wildcards: `doc*` (matches document, documentation, etc.)\n- Field searches: `name:\"meeting notes\"`, `comment:important`\n- Type filtering: `kind:pdf`, `kind:group`, `kind:markdown`, `kind:!group` (exclude groups)\n- Name searches: `name:foo kind:pdf`, `name:~thailand` (contains thailand)\n- Date searches: `kind:pdf created:Yesterday`, `kind:pdf created:#3days`, `created>=2025-07-14 created<=2025-07-21`\n- Tag searches: `tags:urgent`, `tags:(urgent OR important)`\n\n**Correct date syntax:**\n- Recent: `created:Yesterday`, `created:#3days`, `created:#1week`\n- Specific dates: `created>=2025-07-14`, `created<=2025-07-21`\n- Combined: `kind:document created>=2025-07-14 created<=2025-07-21`\n\n**Search scope options (in order of efficiency):**\n1. **useCurrentGroup** - Search in currently selected group (instant)\n2. **groupUuid** - Direct UUID lookup (fastest)\n3. **groupId + databaseName** - Direct ID lookup (fast)\n4. **groupPath** - Direct DEVONthink location path, e.g., '/Trips/2025' (NOT filesystem paths)\n\n**Examples:**\n- Search in current group: `useCurrentGroup: true`\n- Search PDFs only: `recordType: 'PDF'`\n- Search in specific folder by UUID: `groupUuid: '5557A251-0062-4DD9-9DA5-4CFE9DEE627B'`\n- Search in folder by path: `groupPath: '/Trips/2025'`\n- Recent PDFs: `query: 'kind:pdf created:#3days'`\n- Complex query: `query: 'name:foo kind:pdf created>=2025-07-14'`\n\n**Record type filters:** group, markdown, PDF, bookmark, formatted note, txt, rtf, rtfd, webarchive, quicktime, picture, smart group\n\n**Comparison options:**\n- 'no case': Case insensitive\n- 'no umlauts': Diacritics insensitive\n- 'fuzzy': Fuzzy matching\n- 'related': Find related content\n\nNote: Special characters in queries are automatically escaped. The tool returns both the record ID (database-specific) and UUID (globally unique) for each result.",
-  inputSchema: zodToJsonSchema(SearchSchema) as ToolInput,
-  run: search,
+	name: "search",
+	description:
+		"Search for records in DEVONthink. This tool is useful for general text-based queries and can be scoped to a specific group. It supports various comparison options and returns a list of matching records with their properties including both ID and UUID.\n\n**Search query syntax examples:**\n- Simple text: `invoice 2024`\n- Boolean operators: `travel AND (berlin OR munich)`, `invoice NOT paid`\n- Exact phrase: `\"exact phrase here\"`\n- Wildcards: `doc*` (matches document, documentation, etc.)\n- Field searches: `name:\"meeting notes\"`, `comment:important`\n- Type filtering: `kind:pdf`, `kind:group`, `kind:markdown`, `kind:!group` (exclude groups)\n- Name searches: `name:foo kind:pdf`, `name:~thailand` (contains thailand)\n- Date searches: `kind:pdf created:Yesterday`, `kind:pdf created:#3days`, `created>=2025-07-14 created<=2025-07-21`\n- Tag searches: `tags:urgent`, `tags:(urgent OR important)`\n\n**Correct date syntax:**\n- Recent: `created:Yesterday`, `created:#3days`, `created:#1week`\n- Specific dates: `created>=2025-07-14`, `created<=2025-07-21`\n- Combined: `kind:document created>=2025-07-14 created<=2025-07-21`\n\n**Search scope options (in order of efficiency):**\n1. **useCurrentGroup** - Search in currently selected group (instant)\n2. **groupUuid** - Direct UUID lookup (fastest)\n3. **groupId + databaseName** - Direct ID lookup (fast)\n4. **groupPath** - Direct DEVONthink location path, e.g., '/Trips/2025' (NOT filesystem paths)\n\n**Examples:**\n- Search in current group: `useCurrentGroup: true`\n- Search PDFs only: `recordType: 'PDF'`\n- Search in specific folder by UUID: `groupUuid: '5557A251-0062-4DD9-9DA5-4CFE9DEE627B'`\n- Search in folder by path: `groupPath: '/Trips/2025'`\n- Recent PDFs: `query: 'kind:pdf created:#3days'`\n- Complex query: `query: 'name:foo kind:pdf created>=2025-07-14'`\n\n**Record type filters:** group, markdown, PDF, bookmark, formatted note, txt, rtf, rtfd, webarchive, quicktime, picture, smart group\n\n**Comparison options:**\n- 'no case': Case insensitive\n- 'no umlauts': Diacritics insensitive\n- 'fuzzy': Fuzzy matching\n- 'related': Find related content\n\nNote: Special characters in queries are automatically escaped. The tool returns both the record ID (database-specific) and UUID (globally unique) for each result.",
+	inputSchema: zodToJsonSchema(SearchSchema) as ToolInput,
+	run: search,
 };

--- a/src/tools/updateRecordContent.ts
+++ b/src/tools/updateRecordContent.ts
@@ -2,47 +2,44 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
-import {
-  escapeStringForJXA,
-  isJXASafeString,
-} from "../utils/escapeString.js";
+import { escapeStringForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
 
 const UpdateRecordContentSchema = z
-  .object({
-    uuid: z.string().describe("The UUID of the record to update"),
-    content: z.string().describe("The new content for the record"),
-  })
-  .strict();
+	.object({
+		uuid: z.string().describe("The UUID of the record to update"),
+		content: z.string().describe("The new content for the record"),
+	})
+	.strict();
 
 type UpdateRecordContentInput = z.infer<typeof UpdateRecordContentSchema>;
 
 interface UpdateRecordContentResult {
-  success: boolean;
-  error?: string;
-  uuid?: string;
-  name?: string;
-  recordType?: string;
-  updatedProperty?: string;
+	success: boolean;
+	error?: string;
+	uuid?: string;
+	name?: string;
+	recordType?: string;
+	updatedProperty?: string;
 }
 
 const updateRecordContent = async (
-  input: UpdateRecordContentInput
+	input: UpdateRecordContentInput,
 ): Promise<UpdateRecordContentResult> => {
-  const { uuid, content } = input;
+	const { uuid, content } = input;
 
-  // Validate string inputs
-  if (!isJXASafeString(uuid)) {
-    return { success: false, error: "UUID contains invalid characters" };
-  }
-  if (!isJXASafeString(content)) {
-    return { success: false, error: "Content contains invalid characters" };
-  }
+	// Validate string inputs
+	if (!isJXASafeString(uuid)) {
+		return { success: false, error: "UUID contains invalid characters" };
+	}
+	if (!isJXASafeString(content)) {
+		return { success: false, error: "Content contains invalid characters" };
+	}
 
-  const script = `
+	const script = `
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
@@ -101,12 +98,13 @@ const updateRecordContent = async (
     })();
   `;
 
-  return await executeJxa<UpdateRecordContentResult>(script);
+	return await executeJxa<UpdateRecordContentResult>(script);
 };
 
 export const updateRecordContentTool: Tool = {
-  name: "update_record_content",
-  description: "Updates the content of an existing record in DEVONthink while preserving its UUID and all metadata. Works with markdown, text, RTF, formatted notes, and HTML documents. Uses the 'plainText' property for text-based formats and 'source' property for HTML. Since UUIDs are globally unique across all databases, only the UUID is required to identify the record.",
-  inputSchema: zodToJsonSchema(UpdateRecordContentSchema) as ToolInput,
-  run: updateRecordContent,
+	name: "update_record_content",
+	description:
+		"Updates the content of an existing record in DEVONthink while preserving its UUID and all metadata. Works with markdown, text, RTF, formatted notes, and HTML documents. Uses the 'plainText' property for text-based formats and 'source' property for HTML. Since UUIDs are globally unique across all databases, only the UUID is required to identify the record.",
+	inputSchema: zodToJsonSchema(UpdateRecordContentSchema) as ToolInput,
+	run: updateRecordContent,
 };

--- a/src/utils/escapeString.ts
+++ b/src/utils/escapeString.ts
@@ -3,30 +3,30 @@
  * This handles all special characters that could break the script or cause security issues.
  */
 export function escapeStringForJXA(input: string | undefined | null): string {
-  if (input === undefined || input === null) {
-    return "";
-  }
+	if (input === undefined || input === null) {
+		return "";
+	}
 
-  // First, handle backslashes (must be done first to avoid double-escaping)
-  let escaped = input.replace(/\\/g, "\\\\");
+	// First, handle backslashes (must be done first to avoid double-escaping)
+	let escaped = input.replace(/\\/g, "\\\\");
 
-  // Then handle quotes
-  escaped = escaped.replace(/"/g, '\\"');
-  escaped = escaped.replace(/'/g, "\\'");
+	// Then handle quotes
+	escaped = escaped.replace(/"/g, '\\"');
+	escaped = escaped.replace(/'/g, "\\'");
 
-  // Handle newlines, tabs, and other control characters
-  escaped = escaped
-    .replace(/\n/g, "\\n")
-    .replace(/\r/g, "\\r")
-    .replace(/\t/g, "\\t")
-    .replace(/\f/g, "\\f")
-    .replace(/\v/g, "\\v");
+	// Handle newlines, tabs, and other control characters
+	escaped = escaped
+		.replace(/\n/g, "\\n")
+		.replace(/\r/g, "\\r")
+		.replace(/\t/g, "\\t")
+		.replace(/\f/g, "\\f")
+		.replace(/\v/g, "\\v");
 
-  // Handle Unicode characters that might cause issues
-  // Replace zero-width characters and other problematic Unicode
-  escaped = escaped.replace(/\u0000/g, "");
+	// Handle Unicode characters that might cause issues
+	// Replace zero-width characters and other problematic Unicode
+	escaped = escaped.replace(/\u0000/g, "");
 
-  return escaped;
+	return escaped;
 }
 
 /**
@@ -34,43 +34,41 @@ export function escapeStringForJXA(input: string | undefined | null): string {
  * Search queries have additional requirements beyond basic string escaping.
  */
 export function escapeSearchQuery(query: string): string {
-  // First apply basic escaping
-  let escaped = escapeStringForJXA(query);
+	// First apply basic escaping
+	let escaped = escapeStringForJXA(query);
 
-  // DEVONthink search has issues with certain operators
-  // Escape parentheses and other special search characters
-  escaped = escaped
-    .replace(/\(/g, "\\(")
-    .replace(/\)/g, "\\)")
-    .replace(/\[/g, "\\[")
-    .replace(/\]/g, "\\]")
-    .replace(/\*/g, "\\*")
-    .replace(/\?/g, "\\?");
+	// DEVONthink search has issues with certain operators
+	// Escape parentheses and other special search characters
+	escaped = escaped
+		.replace(/\(/g, "\\(")
+		.replace(/\)/g, "\\)")
+		.replace(/\[/g, "\\[")
+		.replace(/\]/g, "\\]")
+		.replace(/\*/g, "\\*")
+		.replace(/\?/g, "\\?");
 
-  return escaped;
+	return escaped;
 }
 
 /**
  * Safely formats a value for JXA script interpolation.
  * Handles different types appropriately.
  */
-export function formatValueForJXA(
-  value: string | number | boolean | undefined | null
-): string {
-  if (value === undefined || value === null) {
-    return "null";
-  }
+export function formatValueForJXA(value: string | number | boolean | undefined | null): string {
+	if (value === undefined || value === null) {
+		return "null";
+	}
 
-  if (typeof value === "string") {
-    return `"${escapeStringForJXA(value)}"`;
-  }
+	if (typeof value === "string") {
+		return `"${escapeStringForJXA(value)}"`;
+	}
 
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
 
-  // For other types, convert to string and escape
-  return `"${escapeStringForJXA(String(value))}"`;
+	// For other types, convert to string and escape
+	return `"${escapeStringForJXA(String(value))}"`;
 }
 
 /**
@@ -78,7 +76,7 @@ export function formatValueForJXA(
  * This is useful when you need to pass user input as a string in JXA.
  */
 export function createJXAStringLiteral(value: string): string {
-  return `"${escapeStringForJXA(value)}"`;
+	return `"${escapeStringForJXA(value)}"`;
 }
 
 /**
@@ -86,10 +84,10 @@ export function createJXAStringLiteral(value: string): string {
  * even after escaping. Returns true if the string is safe to use.
  */
 export function isJXASafeString(input: string): boolean {
-  // Check for null bytes and other control characters that can't be properly escaped
-  if (/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(input)) {
-    return false;
-  }
+	// Check for null bytes and other control characters that can't be properly escaped
+	if (/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(input)) {
+		return false;
+	}
 
-  return true;
+	return true;
 }

--- a/src/utils/jxaHelpers.ts
+++ b/src/utils/jxaHelpers.ts
@@ -219,7 +219,7 @@ function convertDevonthinkRecord(record) {
  * Get all JXA helpers as a single string
  */
 export function getJXAHelpers(): string {
-  return `
+	return `
     // JXA Helper Functions
     ${lookupByUuidHelper}
     ${lookupByIdHelper}
@@ -236,7 +236,7 @@ export function getJXAHelpers(): string {
  * Get specific helpers
  */
 export function getRecordLookupHelpers(): string {
-  return `
+	return `
     ${lookupByUuidHelper}
     ${lookupByIdHelper}
     ${lookupByPathHelper}
@@ -249,20 +249,19 @@ export function getRecordLookupHelpers(): string {
  * Format lookup options for JXA
  */
 export function formatLookupOptions(
-  uuid?: string,
-  id?: number,
-  path?: string,
-  name?: string,
-  databaseName?: string
+	uuid?: string,
+	id?: number,
+	path?: string,
+	name?: string,
+	databaseName?: string,
 ): string {
-  const options: string[] = [];
+	const options: string[] = [];
 
-  if (uuid) options.push(`uuid: ${JSON.stringify(uuid)}`);
-  if (id !== undefined) options.push(`id: ${id}`);
-  if (path) options.push(`path: ${JSON.stringify(path)}`);
-  if (name) options.push(`name: ${JSON.stringify(name)}`);
-  if (databaseName)
-    options.push(`databaseName: ${JSON.stringify(databaseName)}`);
+	if (uuid) options.push(`uuid: ${JSON.stringify(uuid)}`);
+	if (id !== undefined) options.push(`id: ${id}`);
+	if (path) options.push(`path: ${JSON.stringify(path)}`);
+	if (name) options.push(`name: ${JSON.stringify(name)}`);
+	if (databaseName) options.push(`databaseName: ${JSON.stringify(databaseName)}`);
 
-  return `{ ${options.join(", ")} }`;
+	return `{ ${options.join(", ")} }`;
 }

--- a/tests/utils/escapeString.test.ts
+++ b/tests/utils/escapeString.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { escapeStringForJXA, formatValueForJXA } from "../escapeString";
-import { formatLookupOptions } from "../jxaHelpers";
+import { escapeStringForJXA, formatValueForJXA } from "../../src/utils/escapeString";
 
 describe("escapeStringForJXA", () => {
 	it("returns empty string for undefined or null", () => {
@@ -28,19 +27,5 @@ describe("formatValueForJXA", () => {
 	it("converts nullish values to null", () => {
 		expect(formatValueForJXA(null)).toBe("null");
 		expect(formatValueForJXA(undefined)).toBe("null");
-	});
-});
-
-describe("formatLookupOptions", () => {
-	it("creates a properly formatted options object", () => {
-		const result = formatLookupOptions("uuid", 5, "/path", "name", "db");
-		expect(result).toBe(
-			'{ uuid: "uuid", id: 5, path: "/path", name: "name", databaseName: "db" }',
-		);
-	});
-
-	it("omits undefined values", () => {
-		const result = formatLookupOptions(undefined, 1);
-		expect(result).toBe("{ id: 1 }");
 	});
 });

--- a/tests/utils/jxaHelpers.test.ts
+++ b/tests/utils/jxaHelpers.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { formatLookupOptions } from "../../src/utils/jxaHelpers";
+
+describe("formatLookupOptions", () => {
+	it("creates a properly formatted options object", () => {
+		const result = formatLookupOptions("uuid", 5, "/path", "name", "db");
+		expect(result).toBe(
+			'{ uuid: "uuid", id: 5, path: "/path", name: "name", databaseName: "db" }',
+		);
+	});
+
+	it("omits undefined values", () => {
+		const result = formatLookupOptions(undefined, 1);
+		expect(result).toBe("{ id: 1 }");
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "strict": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "skipLibCheck": true
-  },
-  "include": [
-    "./src/**/*.ts"
-  ]
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ES2020",
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"strict": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"skipLibCheck": true
+	},
+	"include": ["./src/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-  },
+	test: {
+		globals: true,
+		environment: "node",
+	},
 });


### PR DESCRIPTION
## Summary
- move lookup option tests into new `jxaHelpers.test.ts`
- relocate test files outside `src` and update imports
- run Biome formatting across entire repository and expose `format`/`format:check` scripts

## Testing
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f5b6a1088330b7640b0e8fb15f82