### PR TITLE
feat(createRecord): Return referenceURL in response

### DIFF
--- a/src/tools/createRecord.ts
+++ b/src/tools/createRecord.ts
@@ -34,6 +34,7 @@ const createRecord = async (
 	recordId?: number;
 	name?: string;
 	uuid?: string;
+	referenceURL?: string;
 	error?: string;
 }> => {
 	const { name, type, content, url, parentGroupUuid, databaseName } = input;
@@ -86,7 +87,8 @@ const createRecord = async (
             success: true,
             recordId: newRecord.id(),
             name: newRecord.name(),
-            uuid: newRecord.uuid()
+            uuid: newRecord.uuid(),
+            referenceURL: newRecord.referenceURL()
           });
         } else {
           return JSON.stringify({
@@ -108,6 +110,7 @@ const createRecord = async (
 		recordId?: number;
 		name?: string;
 		uuid?: string;
+		referenceURL?: string;
 		error?: string;
 	}>(script);
 };


### PR DESCRIPTION
## Summary

This PR adds the `referenceURL` field to the `create_record` response, returning the DEVONthink item link (`x-devonthink-item://UUID`) alongside the existing `uuid` field.

## Motivation

When automating workflows that span multiple applications, the `referenceURL` is essential for creating cross-app links. Common use cases include:

- **OmniFocus Integration**: Create a DEVONthink document, then immediately add a task in OmniFocus with a clickable link back to it
- **Obsidian/Notes**: Reference DEVONthink items from markdown notes using the item URL
- **Calendar Events**: Attach relevant DEVONthink documents to calendar entries
- **Shortcuts/Automation**: Build macOS Shortcuts that chain document creation with other actions

Currently, users must either:
1. Manually construct the URL from the UUID (error-prone, undocumented)
2. Make a second API call to `get_record_properties` (wasteful, adds latency)

This small change eliminates that friction entirely.

## Changes

```diff
// src/tools/createRecord.ts
{
  success: true,
  recordId: newRecord.id(),
  name: newRecord.name(),
- uuid: newRecord.uuid()
+ uuid: newRecord.uuid(),
+ referenceURL: newRecord.referenceURL()
}
```

## Testing

Tested with all record types:
- ✅ Markdown documents
- ✅ Groups (folders)
- ✅ Bookmarks
- ✅ Formatted notes
- ✅ Records created in specific parent groups

Example response:
```json
{
  "success": true,
  "recordId": 14974,
  "name": "My Document",
  "uuid": "98B409E8-A58A-48AE-8EF2-29D3BFC79750",
  "referenceURL": "x-devonthink-item://98B409E8-A58A-48AE-8EF2-29D3BFC79750"
}
```

The returned URLs were verified to open the correct record in DEVONthink via `open "x-devonthink-item://..."`.

## Backward Compatibility

This is a purely additive change. Existing integrations continue to work unchanged—they simply gain access to an additional field.

---

Thanks for maintaining this excellent MCP server! 🙏