### PR TITLE
Fix script corruption in executeJxa shell-escape

### DIFF
--- a/src/applescript/execute.ts
+++ b/src/applescript/execute.ts
@@ -1,9 +1,8 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 export const executeJxa = <T>(script: string): Promise<T> => {
 	return new Promise((resolve, reject) => {
-		const command = `osascript -l JavaScript -e '${script.replace(/'/g, "''")}'`;
-		exec(command, (error, stdout, stderr) => {
+		execFile("osascript", ["-l", "JavaScript", "-e", script], (error, stdout, stderr) => {
 			if (error) {
 				return reject(
 					new McpError(ErrorCode.InternalError, `JXA execution failed: ${error.message}`),


### PR DESCRIPTION
## Summary

`executeJxa` builds the `osascript` command as a shell string and escapes single quotes with `'` → `''`. That isn't a valid bash escape inside a single-quoted string — `''` collapses to nothing, so every apostrophe in the JXA script is silently stripped before reaching `osascript`.

The bug is latent today because the project's JXA strings use double quotes throughout, but any tool emitting a single-quoted JXA string literal (`'foo'`, a contraction in an error message thrown back via `error.toString()`, etc.) would produce either an `osascript` syntax error or, worse, a silently malformed script.

## Fix

Switch from `exec` (shell-interpreted command string) to `execFile` with an argv array. `osascript` receives the script as a single argument — no shell, no escaping needed.

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm test\` passes (12/12)
- [x] \`npm run build\` succeeds
- [x] Manually verified an end-to-end record lookup (\`getRecordWithUuid\` + property access) round-trips valid JSON via the new \`execFile\` path