### PR TITLE
DEVONthink 3 Standard support and correct JXA app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Devonthink MCP Server
 
-This MCP server provides access to DEVONthink functionality via the Model Context Protocol (MCP). It enables listing, searching, creating, modifying, and managing records and databases in DEVONthink Pro on macOS.
+This MCP server provides access to DEVONthink functionality via the Model Context Protocol (MCP). It enables listing, searching, creating, modifying, and managing records and databases in **DEVONthink 3** on macOS (Standard and Pro).
+
+**Edition compatibility:** Core tools work on DEVONthink 3 Standard when Automation permission is granted; Pro-only properties and AI tools degrade gracefully. See [docs/EDITION_COMPATIBILITY.md](./docs/EDITION_COMPATIBILITY.md).
 
 ![screenshot](./screenshot.png)
 
@@ -134,6 +136,11 @@ Add to your Claude configuration:
   }
 }
 ```
+
+## Requirements
+
+- macOS with **DEVONthink 3** installed (registered JXA name: `"DEVONthink 3"`)
+- Grant **Automation** for your MCP host (e.g. Claude Desktop) in System Settings → Privacy & Security
 
 ## Implementation Details
 

--- a/docs/EDITION_COMPATIBILITY.md
+++ b/docs/EDITION_COMPATIBILITY.md
@@ -1,0 +1,71 @@
+# DEVONthink edition compatibility
+
+This MCP server targets **DEVONthink 3** on macOS. It uses **JavaScript for Automation (JXA)** against the app name registered as `"DEVONthink 3"` (not `"DEVONthink"`).
+
+## Editions
+
+| Edition | Core tools (list/search/read/write tags) | Notes |
+|--------|-------------------------------------------|-------|
+| **Standard** | Supported when DEVONthink is running and Automation permission is granted | Some JXA properties and AI APIs are unavailable; tools degrade gracefully |
+| **Pro / Server** | Full feature set | AI classification, compare, and built-in AI tools require Pro capabilities |
+
+The README historically stated “DEVONthink Pro only.” In practice, **Standard exposes enough of the scripting dictionary** for most record and database operations once the correct application name is used. Failures on Standard are usually **missing properties** or **Pro-only APIs**, not `Application can't be found`.
+
+## Application name
+
+```javascript
+Application("DEVONthink 3")  // correct on typical DT3 installs
+Application("DEVONthink")    // fails with error -2700
+```
+
+A filesystem symlink at `/Applications/DEVONthink.app` does **not** fix JXA lookup (macOS resolves by bundle ID / registered name).
+
+## Optional properties (Standard may omit)
+
+These are read or written inside `try/catch` via helpers in `src/utils/jxaHelpers.ts` (`getEditionCompatHelpers()`). If a property is unavailable, it is skipped instead of failing the whole tool call.
+
+### Record (`get_record_properties`, `set_record_properties`)
+
+| Property | Used by |
+|----------|---------|
+| `excludeFromChat` | get / set |
+| `excludeFromClassification` | get / set |
+| `excludeFromSearch` | get / set |
+| `excludeFromSeeAlso` | get / set |
+| `excludeFromTagging` | get / set (groups only for set) |
+| `excludeFromWikiLinking` | get / set |
+| `wordCount` | get (optional) |
+| `characterCount` | get (optional) |
+| `plainText` | get (text record types; optional) |
+
+### Database (`get_open_databases`, `current_database`)
+
+| Property | Notes |
+|----------|--------|
+| `revisionProof` | DEVONthink 4.1+ |
+| `auditProof` | DEVONthink before 4.1 |
+| `comment` | Optional on database object |
+
+### Record metadata (other tools)
+
+| Property | Notes |
+|----------|--------|
+| `referenceURL` | Usually available; lookup by URL uses try/catch where needed |
+
+## Pro-oriented / AI tools
+
+These call DEVONthink APIs that may be absent or limited on Standard:
+
+- `classify` — `theApp.classify(...)`
+- `compare` — similarity / comparison APIs
+- `check_ai_health`, `ask_ai_about_documents`, `create_summary_document`, `get_tool_documentation`
+
+On failure, the tool returns `{ success: false, error: "..." }` rather than crashing the MCP server.
+
+## macOS permissions
+
+Grant **Automation** (and if prompted, **Accessibility**) for Claude Desktop / your terminal to control DEVONthink in **System Settings → Privacy & Security**.
+
+## Contributing
+
+When adding a new JXA property access, use `safeOptionalCall` / `applyRecordExcludeFlags` / `applyDatabaseAuditProof` from `getEditionCompatHelpers()`, or an explicit `try/catch`, and document the property in this file.

--- a/src/applescript/execute.ts
+++ b/src/applescript/execute.ts
@@ -2,7 +2,7 @@ import { execFile } from "child_process";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 export const executeJxa = <T>(script: string): Promise<T> => {
 	return new Promise((resolve, reject) => {
-		execFile("osascript", ["-l", "JavaScript", "-e", script], (error, stdout, stderr) => {
+		execFile("/usr/bin/osascript", ["-l", "JavaScript", "-e", script], (error, stdout, stderr) => {
 			if (error) {
 				return reject(
 					new McpError(ErrorCode.InternalError, `JXA execution failed: ${error.message}`),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * JXA Application() name as registered on macOS.
+ * DEVONthink 3 installs as "DEVONthink 3", not "DEVONthink".
+ */
+export const DEVONTHINK_APPLICATION_NAME = "DEVONthink 3" as const;
+
+/** Expression for embedding in JXA script strings */
+export const JXA_DEVONTHINK_APP = `Application(${JSON.stringify(DEVONTHINK_APPLICATION_NAME)})`;

--- a/src/tools/addTags.ts
+++ b/src/tools/addTags.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -37,7 +38,7 @@ const addTags = async (input: AddTagsInput): Promise<AddTagsResult> => {
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/ai/askAiAboutDocuments.ts
+++ b/src/tools/ai/askAiAboutDocuments.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { JXA_DEVONTHINK_APP } from "../../constants.js";
 import { createDevonThinkTool } from "../base/DevonThinkTool.js";
 import { AI_ENGINES } from "./constants.js";
 
@@ -31,7 +32,7 @@ export const askAiAboutDocumentsTool = createDevonThinkTool({
 		const { documentUuids, question, temperature, model, engine } = input;
 
 		return helpers.wrapInTryCatch(`
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Check if DEVONthink is running

--- a/src/tools/ai/checkAIHealth.ts
+++ b/src/tools/ai/checkAIHealth.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { JXA_DEVONTHINK_APP } from "../../constants.js";
 import { createDevonThinkTool } from "../base/DevonThinkTool.js";
 import { AI_ENGINES } from "./constants.js";
 
@@ -34,7 +35,7 @@ export const checkAIHealthTool = createDevonThinkTool({
 	inputSchema: CheckAIHealthSchema,
 	buildScript: (input, helpers) => {
 		return helpers.wrapInTryCatch(`
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       const result = {};

--- a/src/tools/ai/createSummaryDocument.ts
+++ b/src/tools/ai/createSummaryDocument.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createDevonThinkTool } from "../base/DevonThinkTool.js";
+import { JXA_DEVONTHINK_APP } from "../../constants.js";
 
 const CreateSummaryDocumentSchema = z
 	.object({
@@ -37,7 +38,7 @@ export const createSummaryDocumentTool = createDevonThinkTool({
 		const { documentUuids, summaryType, summaryStyle, parentGroupUuid, customTitle } = input;
 
 		return helpers.wrapInTryCatch(`
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Check if DEVONthink is running

--- a/src/tools/classify.ts
+++ b/src/tools/classify.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -50,7 +51,7 @@ const classify = async (input: ClassifyInput): Promise<ClassifyResult> => {
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/compare.ts
+++ b/src/tools/compare.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -87,7 +88,7 @@ const compare = async (input: CompareInput): Promise<CompareResult> => {
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/convertRecord.ts
+++ b/src/tools/convertRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -101,7 +102,7 @@ const convertRecord = async (input: ConvertRecordInput): Promise<ConvertRecordRe
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/createFromUrl.ts
+++ b/src/tools/createFromUrl.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -64,7 +65,7 @@ const createFromUrl = async (input: CreateFromUrlInput): Promise<CreateFromUrlRe
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/createRecord.ts
+++ b/src/tools/createRecord.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -41,7 +42,7 @@ const createRecord = async (
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/deleteRecord.ts
+++ b/src/tools/deleteRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -50,7 +51,7 @@ const deleteRecord = async (
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/duplicateRecord.ts
+++ b/src/tools/duplicateRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -82,7 +83,7 @@ const duplicateRecord = async (input: DuplicateRecordInput): Promise<DuplicateRe
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/getCurrentDatabase.ts
+++ b/src/tools/getCurrentDatabase.ts
@@ -3,6 +3,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { JXA_DEVONTHINK_APP } from "../constants.js";
+import { getEditionCompatHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -35,6 +36,7 @@ const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
     (() => {
       const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
+      ${getEditionCompatHelpers()}
       
       try {
         const currentDb = theApp.currentDatabase();
@@ -58,21 +60,8 @@ const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
           versioning: currentDb.versioning()
         };
         
-        // Handle audit/revision proof compatibility: before 4.1 vs 4.1 and later
-        try {
-          databaseInfo["revisionProof"] = currentDb.revisionProof(); // 4.1 and later
-        } catch (e) {
-          try {
-            databaseInfo["auditProof"] = currentDb.auditProof(); // before 4.1
-          } catch (e2) {
-            // fallback if neither works - don't add any property
-          }
-        }
-        
-        // Add comment if available
-        if (currentDb.comment && currentDb.comment()) {
-          databaseInfo.comment = currentDb.comment();
-        }
+        applyDatabaseAuditProof(currentDb, databaseInfo);
+        applyDatabaseComment(currentDb, databaseInfo);
         
         return JSON.stringify({
           success: true,

--- a/src/tools/getCurrentDatabase.ts
+++ b/src/tools/getCurrentDatabase.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -32,7 +33,7 @@ interface GetCurrentDatabaseResult {
 const getCurrentDatabase = async (): Promise<GetCurrentDatabaseResult> => {
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/getOpenDatabases.ts
+++ b/src/tools/getOpenDatabases.ts
@@ -3,6 +3,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { JXA_DEVONTHINK_APP } from "../constants.js";
+import { getEditionCompatHelpers } from "../utils/jxaHelpers.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -36,6 +37,7 @@ const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
     (() => {
       const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
+      ${getEditionCompatHelpers()}
       
       try {
         const databases = theApp.databases();
@@ -61,21 +63,8 @@ const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
             versioning: db.versioning()
           };
           
-          // Handle audit/revision proof compatibility: before 4.1 vs 4.1 and later
-          try {
-            info["revisionProof"] = db.revisionProof(); // 4.1 and later
-          } catch (e) {
-            try {
-              info["auditProof"] = db.auditProof(); // before 4.1
-            } catch (e2) {
-              // fallback if neither works - don't add any property
-            }
-          }
-          
-          // Add comment if available
-          if (db.comment && db.comment()) {
-            info.comment = db.comment();
-          }
+          applyDatabaseAuditProof(db, info);
+          applyDatabaseComment(db, info);
           
           return info;
         });

--- a/src/tools/getOpenDatabases.ts
+++ b/src/tools/getOpenDatabases.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -33,7 +34,7 @@ interface GetOpenDatabasesResult {
 const getOpenDatabases = async (): Promise<GetOpenDatabasesResult> => {
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/getRecordByIdentifier.ts
+++ b/src/tools/getRecordByIdentifier.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -75,7 +76,7 @@ const getRecordByIdentifier = async (input: GetRecordByIdentifierInput): Promise
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
 
       // Inject helper functions

--- a/src/tools/getRecordContent.ts
+++ b/src/tools/getRecordContent.ts
@@ -3,7 +3,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
-import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { getRecordLookupHelpers, getEditionCompatHelpers } from "../utils/jxaHelpers.js";
 import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
@@ -44,6 +44,7 @@ const getRecordContent = async (input: GetRecordContentInput): Promise<GetRecord
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions
+      ${getEditionCompatHelpers()}
       ${getRecordLookupHelpers()}
       
       try {
@@ -76,11 +77,11 @@ const getRecordContent = async (input: GetRecordContentInput): Promise<GetRecord
         const recordType = record.recordType();
 
         if (recordType === "markdown" || recordType === "txt" || recordType === "formatted note") {
-            content = record.plainText();
+            content = safeOptionalCall(() => record.plainText());
         } else if (recordType === "rtf") {
-            content = record.richText();
+            content = safeOptionalCall(() => record.richText());
         } else {
-            content = record.plainText();
+            content = safeOptionalCall(() => record.plainText());
         }
         
         return JSON.stringify({

--- a/src/tools/getRecordContent.ts
+++ b/src/tools/getRecordContent.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -39,7 +40,7 @@ const getRecordContent = async (input: GetRecordContentInput): Promise<GetRecord
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/getRecordProperties.ts
+++ b/src/tools/getRecordProperties.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -84,7 +85,7 @@ const getRecordProperties = async (input: GetRecordPropertiesInput): Promise<Rec
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
 
       // Inject helper functions

--- a/src/tools/getRecordProperties.ts
+++ b/src/tools/getRecordProperties.ts
@@ -3,7 +3,11 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
-import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import {
+	getRecordLookupHelpers,
+	getDatabaseHelper,
+	getEditionCompatHelpers,
+} from "../utils/jxaHelpers.js";
 import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
@@ -89,6 +93,7 @@ const getRecordProperties = async (input: GetRecordPropertiesInput): Promise<Rec
       theApp.includeStandardAdditions = true;
 
       // Inject helper functions
+      ${getEditionCompatHelpers()}
       ${getRecordLookupHelpers()}
       ${getDatabaseHelper}
 
@@ -148,26 +153,22 @@ const getRecordProperties = async (input: GetRecordPropertiesInput): Promise<Rec
           label: targetRecord.label(),
           flag: targetRecord.flag(),
           unread: targetRecord.unread(),
-          locked: targetRecord.locking(),
-          wordCount: targetRecord.wordCount(),
-          characterCount: targetRecord.characterCount()
+          locked: targetRecord.locking()
         };
 
-        // Add optional exclusion flags if available on this record type
-        try { if (targetRecord.excludeFromChat && targetRecord.excludeFromChat() !== undefined) { properties.excludeFromChat = targetRecord.excludeFromChat(); } } catch (e) {}
-        try { if (targetRecord.excludeFromClassification && targetRecord.excludeFromClassification() !== undefined) { properties.excludeFromClassification = targetRecord.excludeFromClassification(); } } catch (e) {}
-        try { if (targetRecord.excludeFromSearch && targetRecord.excludeFromSearch() !== undefined) { properties.excludeFromSearch = targetRecord.excludeFromSearch(); } } catch (e) {}
-        try { if (targetRecord.excludeFromSeeAlso && targetRecord.excludeFromSeeAlso() !== undefined) { properties.excludeFromSeeAlso = targetRecord.excludeFromSeeAlso(); } } catch (e) {}
-        try { if (targetRecord.excludeFromTagging && targetRecord.excludeFromTagging() !== undefined) { properties.excludeFromTagging = targetRecord.excludeFromTagging(); } } catch (e) {}
-        try { if (targetRecord.excludeFromWikiLinking && targetRecord.excludeFromWikiLinking() !== undefined) { properties.excludeFromWikiLinking = targetRecord.excludeFromWikiLinking(); } } catch (e) {}
+        const wordCount = safeOptionalCall(() => targetRecord.wordCount());
+        if (wordCount !== undefined) properties.wordCount = wordCount;
+        const characterCount = safeOptionalCall(() => targetRecord.characterCount());
+        if (characterCount !== undefined) properties.characterCount = characterCount;
+
+        applyRecordExcludeFlags(targetRecord, properties);
 
         // Only include plain text for text-based records and limit size
         if (targetRecord.recordType() === "markdown" ||
             targetRecord.recordType() === "formatted note" ||
             targetRecord.recordType() === "txt") {
-          const plainText = targetRecord.plainText();
+          const plainText = safeOptionalCall(() => targetRecord.plainText());
           if (plainText && plainText.length > 0) {
-            // Limit to first 1000 characters to avoid overwhelming responses
             properties.plainText = plainText.length > 1000 ?
               plainText.substring(0, 1000) + "..." :
               plainText;

--- a/src/tools/getSelectedRecords.ts
+++ b/src/tools/getSelectedRecords.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -35,7 +36,7 @@ interface GetSelectedRecordsResult {
 const getSelectedRecords = async (): Promise<GetSelectedRecordsResult> => {
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/importFile.ts
+++ b/src/tools/importFile.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -61,7 +62,7 @@ const importFile = async (input: ImportFileInput): Promise<ImportFileResult> => 
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
 
       ${getDatabaseHelper}

--- a/src/tools/isRunning.ts
+++ b/src/tools/isRunning.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -10,7 +11,7 @@ const IsRunningSchema = z.object({}).strict();
 
 const isRunning = async (): Promise<{ isRunning: boolean }> => {
 	const script = `
-    const app = Application("DEVONthink");
+    const app = ${JXA_DEVONTHINK_APP};
     const isRunning = app.running();
     JSON.stringify({ isRunning });
   `;

--- a/src/tools/listGroupContent.ts
+++ b/src/tools/listGroupContent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -56,7 +57,7 @@ const listGroupContent = async (input: ListGroupContentInput): Promise<ListGroup
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/lookupRecord.ts
+++ b/src/tools/lookupRecord.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -49,7 +50,7 @@ const lookupRecord = async (input: LookupRecordInput): Promise<LookupResult> => 
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       try {

--- a/src/tools/moveRecord.ts
+++ b/src/tools/moveRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -61,7 +62,7 @@ const moveRecord = async (
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/removeTags.ts
+++ b/src/tools/removeTags.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -44,7 +45,7 @@ const removeTags = async (input: RemoveTagsInput): Promise<RemoveTagsResult> => 
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/renameRecord.ts
+++ b/src/tools/renameRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -39,7 +40,7 @@ const renameRecord = async (input: RenameRecordInput): Promise<RenameRecordResul
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/replicateRecord.ts
+++ b/src/tools/replicateRecord.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, formatValueForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper, isGroupHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -80,7 +81,7 @@ const replicateRecord = async (input: ReplicateRecordInput): Promise<ReplicateRe
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 import {
 	escapeSearchQuery,
 	formatValueForJXA,
@@ -160,7 +161,7 @@ const search = async (input: SearchInput): Promise<SearchResult> => {
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/tools/setRecordProperties.ts
+++ b/src/tools/setRecordProperties.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers, getDatabaseHelper } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -86,7 +87,7 @@ const setRecordProperties = async (
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
 
       // Inject helper functions

--- a/src/tools/updateRecordContent.ts
+++ b/src/tools/updateRecordContent.ts
@@ -4,6 +4,7 @@ import { Tool, ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { executeJxa } from "../applescript/execute.js";
 import { escapeStringForJXA, isJXASafeString } from "../utils/escapeString.js";
 import { getRecordLookupHelpers } from "../utils/jxaHelpers.js";
+import { JXA_DEVONTHINK_APP } from "../constants.js";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -41,7 +42,7 @@ const updateRecordContent = async (
 
 	const script = `
     (() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       
       // Inject helper functions

--- a/src/utils/jxaHelpers.ts
+++ b/src/utils/jxaHelpers.ts
@@ -187,6 +187,76 @@ function isVersion41OrLater(theApp) {
 }`;
 
 /**
+ * Safely call a zero-arg getter; returns undefined if missing or throws (e.g. Standard edition).
+ */
+export const safeOptionalCallHelper = `
+function safeOptionalCall(getter) {
+  try {
+    const value = getter();
+    if (value !== undefined && value !== null) return value;
+  } catch (e) {}
+  return undefined;
+}`;
+
+/**
+ * Database audit/revision proof — version-dependent (4.1+ vs earlier).
+ */
+export const applyDatabaseAuditProofHelper = `
+function applyDatabaseAuditProof(db, info) {
+  try {
+    info.revisionProof = db.revisionProof();
+  } catch (e) {
+    try {
+      info.auditProof = db.auditProof();
+    } catch (e2) {}
+  }
+}`;
+
+/**
+ * Optional database comment.
+ */
+export const applyDatabaseCommentHelper = `
+function applyDatabaseComment(db, info) {
+  const comment = safeOptionalCall(() => db.comment());
+  if (comment) info.comment = comment;
+}`;
+
+/**
+ * Record exclude* flags — often unavailable on DEVONthink Standard.
+ */
+export const applyRecordExcludeFlagsHelper = `
+function applyRecordExcludeFlags(record, properties) {
+  const names = [
+    "excludeFromChat",
+    "excludeFromClassification",
+    "excludeFromSearch",
+    "excludeFromSeeAlso",
+    "excludeFromTagging",
+    "excludeFromWikiLinking"
+  ];
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    try {
+      if (record[name] && record[name]() !== undefined) {
+        properties[name] = record[name]();
+      }
+    } catch (e) {}
+  }
+}`;
+
+/**
+ * Helpers for DEVONthink edition / version differences (inject into JXA scripts).
+ */
+export function getEditionCompatHelpers(): string {
+	return `
+    ${safeOptionalCallHelper}
+    ${applyDatabaseAuditProofHelper}
+    ${applyDatabaseCommentHelper}
+    ${applyRecordExcludeFlagsHelper}
+  `;
+}
+
+/**
  * Helper to get database by name or use current
  */
 export const getDatabaseHelper = `
@@ -228,12 +298,15 @@ function convertDevonthinkRecord(record) {
     
     // Size and counts
     converted["size"] = record.size();
-    converted["wordCount"] = record.wordCount();
-    converted["characterCount"] = record.characterCount();
+    const wordCount = safeOptionalCall(() => record.wordCount());
+    if (wordCount !== undefined) converted["wordCount"] = wordCount;
+    const characterCount = safeOptionalCall(() => record.characterCount());
+    if (characterCount !== undefined) converted["characterCount"] = characterCount;
     
     // URLs and aliases
     converted["url"] = record.url();
-    converted["referenceURL"] = record.referenceURL();
+    const referenceURL = safeOptionalCall(() => record.referenceURL());
+    if (referenceURL !== undefined) converted["referenceURL"] = referenceURL;
     converted["aliases"] = record.aliases();
     
     // Tags and metadata
@@ -246,6 +319,8 @@ function convertDevonthinkRecord(record) {
     converted["flagged"] = record.flagged();
     converted["unread"] = record.unread();
     converted["locking"] = record.locking();
+
+    applyRecordExcludeFlags(record, converted);
     
     // Database info
     const db = record.database();
@@ -266,6 +341,7 @@ function convertDevonthinkRecord(record) {
 export function getJXAHelpers(): string {
 	return `
     // JXA Helper Functions
+    ${getEditionCompatHelpers()}
     ${lookupByUuidHelper}
     ${lookupByIdHelper}
     ${lookupByPathHelper}

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -2,6 +2,7 @@ import { executeJxa } from "../../src/applescript/execute.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { JXA_DEVONTHINK_APP } from "../../src/constants.js";
 
 export interface TestContext {
 	dbPath: string;
@@ -29,7 +30,7 @@ export function cleanupContextFile(): void {
 
 export async function jxa<T>(script: string): Promise<T> {
 	return executeJxa<T>(`(() => {
-    const theApp = Application("DEVONthink");
+    const theApp = ${JXA_DEVONTHINK_APP};
     theApp.includeStandardAdditions = true;
     try {
       ${script}

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { writeTestContext, cleanupContextFile, type TestContext } from "./helpers.js";
+import { JXA_DEVONTHINK_APP } from "../../src/constants.js";
 
 let ctx: TestContext;
 
@@ -36,7 +37,7 @@ export async function setup() {
 		error?: string;
 	}>(
 		`(() => {
-      const theApp = Application("DEVONthink");
+      const theApp = ${JXA_DEVONTHINK_APP};
       theApp.includeStandardAdditions = true;
       try {
         const db = theApp.createDatabase("${dbPath}");
@@ -70,7 +71,7 @@ export async function teardown() {
 	try {
 		await executeJxa(
 			`(() => {
-        const theApp = Application("DEVONthink");
+        const theApp = ${JXA_DEVONTHINK_APP};
         theApp.includeStandardAdditions = true;
         const databases = theApp.databases();
         for (let i = 0; i < databases.length; i++) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,12 @@
 		"moduleResolution": "node",
 		"esModuleInterop": true,
 		"strict": true,
+		"isolatedModules": true,
+		"incremental": true,
 		"outDir": "./dist",
 		"rootDir": "./src",
 		"skipLibCheck": true
 	},
-	"include": ["./src/**/*.ts"]
+	"include": ["./src/**/*.ts"],
+	"exclude": ["./dist", "./node_modules", "./tests"]
 }


### PR DESCRIPTION
## Summary

- Fixes JXA `Application()` lookup on typical DEVONthink 3 installs by using the registered name **`"DEVONthink 3"`** instead of `"DEVONthink"` (error `-2700` otherwise).
- Adds [docs/EDITION_COMPATIBILITY.md](docs/EDITION_COMPATIBILITY.md) listing Standard-incompatible / optional JXA properties and Pro-only tools.
- Centralizes safe optional property access in `getEditionCompatHelpers()` (`safeOptionalCall`, `applyRecordExcludeFlags`, `applyDatabaseAuditProof`, `applyDatabaseComment`) and uses it in database/record tools so **DEVONthink 3 Standard** degrades gracefully instead of failing entire MCP calls.
- Uses `/usr/bin/osascript` for reliable PATH when launched from GUI hosts (e.g. Claude Desktop).
- Tightens `tsconfig.json` (`isolatedModules`, `incremental`, exclude `tests`/`dist`) to reduce `tsc` memory use on install.

## Motivation

Users on **DEVONthink 3 Standard** (and installs where the app registers as `"DEVONthink 3"`) could not use this server: wrong app name broke all tools, and unguarded Pro-only JXA properties caused hard failures. This matches behavior discussed in community debugging (symlinks do not fix JXA app resolution).

## Test plan

- [ ] `npm run build` on macOS (verify `tsc` completes with updated tsconfig)
- [ ] `npm start` / MCP `initialize` with DEVONthink 3 running
- [ ] `is_running`, `get_open_databases`, `current_database` on **Standard** edition
- [ ] `get_record_properties` on a text record — optional fields omitted when unavailable, core metadata present
- [ ] `get_record_content` on markdown/txt record
- [ ] Pro-only tools (`classify`, AI tools) still return structured `{ success: false, error }` on Standard rather than crashing the server


Made with [Cursor](https://cursor.com)