### PR TITLE
fix(lookupRecord): search every open database when databaseName is omitted

### DIFF
--- a/src/tools/lookupRecord.ts
+++ b/src/tools/lookupRecord.ts
@@ -17,7 +17,12 @@ const LookupRecordSchema = z
 			.boolean()
 			.optional()
 			.describe("Match any tag instead of all (for lookupType 'tags')"),
-		databaseName: z.string().optional().describe("Database to search in (optional)"),
+		databaseName: z
+			.string()
+			.optional()
+			.describe(
+				"Database to scope the lookup to. If omitted, every open database is searched.",
+			),
 		limit: z.number().optional().describe("Maximum results to return (optional)"),
 	})
 	.strict();
@@ -51,73 +56,102 @@ const lookupRecord = async (input: LookupRecordInput): Promise<LookupResult> => 
     (() => {
       const theApp = Application("DEVONthink");
       theApp.includeStandardAdditions = true;
-      
+
       try {
-        let searchDatabase;
-        
-        // Determine search database
+        // Determine the set of databases to search.
+        // If a databaseName is supplied, scope to that one database.
+        // Otherwise, iterate every open database — DEVONthink's lookupRecordsWith*
+        // APIs do not natively support "all databases" the way search() does, so we
+        // must call them once per database and union the results.
+        let searchDatabases;
         if ("${databaseName || ""}") {
           const databases = theApp.databases();
-          searchDatabase = databases.find(db => db.name() === "${databaseName}");
-          if (!searchDatabase) {
+          const targetDb = databases.find(db => db.name() === "${databaseName}");
+          if (!targetDb) {
             return JSON.stringify({
               success: false,
               error: "Database not found: ${databaseName}"
             });
           }
+          searchDatabases = [targetDb];
         } else {
-          searchDatabase = theApp.currentDatabase();
+          searchDatabases = theApp.databases();
         }
-        
-        let searchResults;
-        const searchOptions = { in: searchDatabase };
-        
-        // Perform the appropriate lookup
-        switch ("${lookupType}") {
-          case "filename":
-            searchResults = theApp.lookupRecordsWithFile("${value}", { in: searchDatabase });
-            break;
-          case "path":
-            searchResults = theApp.lookupRecordsWithPath("${value}", { in: searchDatabase });
-            break;
-          case "url": {
-            const urlValue = "${value}";
-            const dtPrefix = "x-devonthink-item://";
-            if (urlValue.startsWith(dtPrefix)) {
-              const identifier = decodeURIComponent(urlValue.substring(dtPrefix.length));
-              const record = theApp.getRecordWithUuid(identifier);
-              if (record && record.exists()) {
-                searchResults = [record];
+
+        // lookupRecordsWith* returns AppleScript reference arrays; collect into
+        // a plain array as we go so we can dedupe by UUID across databases.
+        const seen = {};
+        let searchResults = [];
+
+        for (let dbIdx = 0; dbIdx < searchDatabases.length; dbIdx++) {
+          const searchDatabase = searchDatabases[dbIdx];
+          let dbResults;
+
+          switch ("${lookupType}") {
+            case "filename":
+              dbResults = theApp.lookupRecordsWithFile("${value}", { in: searchDatabase });
+              break;
+            case "path":
+              dbResults = theApp.lookupRecordsWithPath("${value}", { in: searchDatabase });
+              break;
+            case "url": {
+              const urlValue = "${value}";
+              const dtPrefix = "x-devonthink-item://";
+              if (urlValue.startsWith(dtPrefix)) {
+                // x-devonthink-item:// resolves globally via UUID — do it once,
+                // not per-database, then short-circuit the loop.
+                if (dbIdx === 0) {
+                  const identifier = decodeURIComponent(urlValue.substring(dtPrefix.length));
+                  const record = theApp.getRecordWithUuid(identifier);
+                  if (record && record.exists()) {
+                    dbResults = [record];
+                  } else {
+                    dbResults = [];
+                  }
+                  dbIdx = searchDatabases.length; // exit the for-loop after this iter
+                } else {
+                  dbResults = [];
+                }
               } else {
-                searchResults = [];
+                dbResults = theApp.lookupRecordsWithURL(decodeURIComponent(urlValue), { in: searchDatabase });
               }
-            } else {
-              searchResults = theApp.lookupRecordsWithURL(decodeURIComponent(urlValue), { in: searchDatabase });
+              break;
             }
-            break;
+            case "comment":
+              dbResults = theApp.lookupRecordsWithComment("${value}", { in: searchDatabase });
+              break;
+            case "contentHash":
+              dbResults = theApp.lookupRecordsWithContentHash("${value}", { in: searchDatabase });
+              break;
+            case "tags": {
+              const tagArray = ${tags ? JSON.stringify(tags) : "[]"};
+              if (tagArray.length === 0 && "${value}") {
+                tagArray.push("${value}");
+              }
+              const tagOptions = { in: searchDatabase };
+              if (${matchAnyTag}) {
+                tagOptions.any = true;
+              }
+              dbResults = theApp.lookupRecordsWithTags(tagArray, tagOptions);
+              break;
+            }
+            default:
+              return JSON.stringify({
+                success: false,
+                error: "Invalid lookup type: ${lookupType}"
+              });
           }
-          case "comment":
-            searchResults = theApp.lookupRecordsWithComment("${value}", { in: searchDatabase });
-            break;
-          case "contentHash":
-            searchResults = theApp.lookupRecordsWithContentHash("${value}", { in: searchDatabase });
-            break;
-          case "tags":
-            const tagArray = ${tags ? JSON.stringify(tags) : "[]"};
-            if (tagArray.length === 0 && "${value}") {
-              tagArray.push("${value}");
+
+          if (dbResults && dbResults.length > 0) {
+            for (let i = 0; i < dbResults.length; i++) {
+              const rec = dbResults[i];
+              const uuid = rec.uuid();
+              if (!seen[uuid]) {
+                seen[uuid] = true;
+                searchResults.push(rec);
+              }
             }
-            const tagOptions = { in: searchDatabase };
-            if (${matchAnyTag}) {
-              tagOptions.any = true;
-            }
-            searchResults = theApp.lookupRecordsWithTags(tagArray, tagOptions);
-            break;
-          default:
-            return JSON.stringify({
-              success: false,
-              error: "Invalid lookup type: ${lookupType}"
-            });
+          }
         }
         
         if (!searchResults || searchResults.length === 0) {
@@ -177,7 +211,7 @@ const lookupRecord = async (input: LookupRecordInput): Promise<LookupResult> => 
 export const lookupRecordTool: Tool = {
 	name: "lookup_record",
 	description:
-		'Look up records in DEVONthink by a specific attribute.\n\nExample:\n{\n  "lookupType": "filename",\n  "value": "report.pdf"\n}',
+		'Look up records in DEVONthink by a specific attribute.\n\nBy default the lookup spans every open database; pass "databaseName" to scope to a single database.\n\nExample:\n{\n  "lookupType": "filename",\n  "value": "report.pdf"\n}',
 	inputSchema: zodToJsonSchema(LookupRecordSchema) as ToolInput,
 	run: lookupRecord,
 };

--- a/tests/tools/lookupRecord.test.ts
+++ b/tests/tools/lookupRecord.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { executeJxaMock } = vi.hoisted(() => ({
+	executeJxaMock: vi.fn(),
+}));
+
+vi.mock("../../src/applescript/execute.js", () => ({
+	executeJxa: executeJxaMock,
+}));
+
+import { lookupRecordTool } from "../../src/tools/lookupRecord.js";
+
+describe("lookupRecordTool", () => {
+	beforeEach(() => {
+		executeJxaMock.mockReset();
+		executeJxaMock.mockResolvedValue({ success: true, results: [], totalCount: 0 });
+	});
+
+	describe("default scope (no databaseName)", () => {
+		it("iterates every open database when databaseName is omitted", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "tags",
+				value: "",
+				tags: ["regression"],
+			});
+
+			const [script] = executeJxaMock.mock.calls[0];
+			// The script must walk all databases, not fall back to currentDatabase().
+			expect(script).toContain("searchDatabases = theApp.databases();");
+			expect(script).not.toContain("theApp.currentDatabase()");
+		});
+
+		it("leaves the database-name guard inert (empty literal) when no databaseName is supplied", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "filename",
+				value: "report.pdf",
+			});
+
+			const [script] = executeJxaMock.mock.calls[0];
+			// The conditional checks "${databaseName || ''}" — with no databaseName the
+			// runtime condition is `if ("")`, so the scoped branch never runs.
+			expect(script).toContain('if ("")');
+		});
+	});
+
+	describe("scoped (databaseName supplied)", () => {
+		it("scopes to the named database when databaseName is supplied", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "filename",
+				value: "report.pdf",
+				databaseName: "MyDB",
+			});
+
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain('db.name() === "MyDB"');
+			expect(script).toContain("searchDatabases = [targetDb];");
+			expect(script).toContain("Database not found: MyDB");
+		});
+	});
+
+	describe("lookup type dispatch", () => {
+		it("dispatches to lookupRecordsWithFile for filename", async () => {
+			await lookupRecordTool.run?.({ lookupType: "filename", value: "report.pdf" });
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain(
+				'theApp.lookupRecordsWithFile("report.pdf", { in: searchDatabase })',
+			);
+		});
+
+		it("dispatches to lookupRecordsWithPath for path", async () => {
+			await lookupRecordTool.run?.({ lookupType: "path", value: "/Inbox/Note" });
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain(
+				'theApp.lookupRecordsWithPath("/Inbox/Note", { in: searchDatabase })',
+			);
+		});
+
+		it("dispatches to lookupRecordsWithComment for comment", async () => {
+			await lookupRecordTool.run?.({ lookupType: "comment", value: "hello" });
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain(
+				'theApp.lookupRecordsWithComment("hello", { in: searchDatabase })',
+			);
+		});
+
+		it("dispatches to lookupRecordsWithContentHash for contentHash", async () => {
+			await lookupRecordTool.run?.({ lookupType: "contentHash", value: "abc123" });
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain(
+				'theApp.lookupRecordsWithContentHash("abc123", { in: searchDatabase })',
+			);
+		});
+
+		it("dispatches to lookupRecordsWithTags for tags and honors matchAnyTag", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "tags",
+				value: "",
+				tags: ["a", "b"],
+				matchAnyTag: true,
+			});
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain('const tagArray = ["a","b"];');
+			expect(script).toContain("if (true) {");
+			expect(script).toContain("tagOptions.any = true;");
+			expect(script).toContain("theApp.lookupRecordsWithTags(tagArray, tagOptions);");
+		});
+	});
+
+	describe("url lookup", () => {
+		it("uses getRecordWithUuid shortcut for x-devonthink-item URLs and short-circuits the db loop", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "url",
+				value: "x-devonthink-item://1234-5678",
+			});
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain('const dtPrefix = "x-devonthink-item://";');
+			expect(script).toContain("theApp.getRecordWithUuid(identifier);");
+			expect(script).toContain("dbIdx = searchDatabases.length;");
+		});
+
+		it("falls back to lookupRecordsWithURL for non-DT URLs", async () => {
+			await lookupRecordTool.run?.({
+				lookupType: "url",
+				value: "https://example.com/page",
+			});
+			const [script] = executeJxaMock.mock.calls[0];
+			expect(script).toContain(
+				"theApp.lookupRecordsWithURL(decodeURIComponent(urlValue), { in: searchDatabase })",
+			);
+		});
+	});
+
+	it("dedupes results by UUID across databases", async () => {
+		await lookupRecordTool.run?.({ lookupType: "filename", value: "shared.md" });
+		const [script] = executeJxaMock.mock.calls[0];
+		expect(script).toContain("const seen = {};");
+		expect(script).toContain("if (!seen[uuid]) {");
+	});
+});


### PR DESCRIPTION
## Problem

`lookup_record` silently scopes to `theApp.currentDatabase()` when `databaseName` is omitted, masking the fact that other open databases were never searched. Callers see `success: true` with empty results and have no way to tell whether the record genuinely doesn't exist or just lives in a database other than the one the user happens to have focused.

Concretely (on a session where `currentDatabase` is database A):

```jsonc
// Record with tag "x" exists in database B
{ "lookupType": "tags", "tags": ["x"] }
// → { success: true, results: [], totalCount: 0 }  ❌
```

The same call succeeds the moment you pass `databaseName: "B"`. The bug was discovered during regression testing against DEVONthink 4 — six different `lookupType` calls all returned 0 results despite the records being present and `get_record_properties` finding them by UUID in the same session.

## Fix

When `databaseName` is supplied: scope to that one database (unchanged from before).

When it is omitted: iterate `theApp.databases()` and union the per-database results, deduplicating by UUID.

Unlike `theApp.search()`, the `lookupRecordsWithFile/Path/URL/Comment/ContentHash/Tags` APIs don't natively span all open databases when `in:` is omitted — they appear to return nothing in that case — so the union has to be done in the script. The cost is one AppleScript call per open database, capped by the existing `limit` parameter on the result side.

The `x-devonthink-item://` URL shortcut continues to resolve globally via `getRecordWithUuid` and short-circuits the loop after the first iteration.

Schema description for `databaseName` and the tool's `description` string have been updated so callers know the default scope is "every open database".

## Test plan

- [x] `npm test` — 27/27 pass, including 11 new tests in `tests/tools/lookupRecord.test.ts` covering:
  - Default-scope behavior (no `databaseName` → iterates `theApp.databases()`, doesn't fall back to `currentDatabase()`)
  - Scoped behavior (`databaseName: "MyDB"` → resolves to `[targetDb]`)
  - All six `lookupType` branches dispatch to the correct AppleScript API
  - `x-devonthink-item://` shortcut short-circuits the loop
  - `matchAnyTag` flag is honored
  - UUID dedup across databases
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] End-to-end verification against a live DEVONthink session with 8 open databases:
  - `tags: ["regression"]` (no `databaseName`) → finds the record in `GTD Reference` (previously returned 0)
  - `filename: "X.md"` (no `databaseName`) → finds the record
  - `tags: ["regression"], databaseName: "King"` → 0 (King doesn't have this tag — explicit scope honored)
  - `tags: ["regression"], databaseName: "GTD Reference"` → 1

## Notes

- Behavior change: callers that *relied* on the implicit current-database scoping will now see results from other open databases. In practice this is strictly more useful — the prior behavior was silent narrowing — but worth flagging for the release notes.
- A follow-up PR will harden the JXA string escaping in `lookupRecord.ts` (raw `${value}` interpolation can still break the script on values containing double quotes / newlines). Kept separate to keep this PR focused on the scope fix.